### PR TITLE
Docs/add jsdoc hooks

### DIFF
--- a/apps/web/hooks/useAuth.ts
+++ b/apps/web/hooks/useAuth.ts
@@ -3,11 +3,44 @@ import { useWalletStore } from '@/store/wallet';
 import { signTransaction } from '@stellar/freighter-api';
 import { Networks } from '@stellar/stellar-sdk';
 
+/**
+ * Custom hook for authenticating the connected Stellar wallet via SEP-10.
+ *
+ * Performs a three-step challenge-sign-verify flow:
+ * 1. Fetches a challenge transaction XDR from the indexer API.
+ * 2. Signs the XDR with the Freighter wallet extension.
+ * 3. Submits the signed XDR to the indexer to receive a JWT.
+ *
+ * Requires a wallet to be connected first (i.e. `useWallet` must have been called).
+ *
+ * @returns An object containing:
+ *   - `token` — The JWT string when authenticated, otherwise `null`.
+ *   - `isAuthenticated` — `true` when a valid JWT token is present.
+ *   - `loading` — `true` while the authentication request is in progress.
+ *   - `error` — Error message string if authentication failed, otherwise `null`.
+ *   - `login` — Async function that initiates the SEP-10 auth flow.
+ *   - `logout` — Function that clears the JWT token and disconnects the wallet.
+ *
+ * @throws All fetch and signing errors are caught internally and surfaced via `error`.
+ *   If no wallet address is connected, `login` sets `error` to `'Wallet not connected'`.
+ *
+ * @example
+ * const { isAuthenticated, login, logout, loading, error } = useAuth();
+ */
 export function useAuth() {
   const { address, token, setToken, disconnect } = useWalletStore();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  /**
+   * Initiates the SEP-10 wallet authentication flow.
+   *
+   * Fetches a challenge XDR from `NEXT_PUBLIC_INDEXER_API_URL`, signs it via
+   * Freighter using `NEXT_PUBLIC_NETWORK_PASSPHRASE` (defaults to Testnet),
+   * then submits the signed transaction to obtain and store a JWT.
+   *
+   * @throws Sets `error` state instead of throwing; caller does not need try/catch.
+   */
   const login = async () => {
     if (!address) {
       setError('Wallet not connected');
@@ -19,7 +52,7 @@ export function useAuth() {
 
     try {
       const apiBaseUrl = process.env.NEXT_PUBLIC_INDEXER_API_URL || 'http://localhost:8080';
-      
+
       // 1. Fetch challenge XDR
       const challengeRes = await fetch(`${apiBaseUrl}/auth?address=${address}`);
       if (!challengeRes.ok) {
@@ -60,6 +93,9 @@ export function useAuth() {
     }
   };
 
+  /**
+   * Logs the user out by clearing the JWT token and disconnecting the wallet.
+   */
   const logout = () => {
     setToken(null);
     disconnect();

--- a/apps/web/hooks/useInvoices.ts
+++ b/apps/web/hooks/useInvoices.ts
@@ -6,6 +6,41 @@ import { useWalletStore } from '@/store/wallet';
 const invoiceContractID = process.env.NEXT_PUBLIC_INVOICE_CONTRACT_ID || '';
 const poolContractID = process.env.NEXT_PUBLIC_POOL_CONTRACT_ID || '';
 
+/**
+ * Custom hook for managing invoice lifecycle operations on the TrusTrove platform.
+ *
+ * Combines React Query for data fetching with on-chain mutations via the TrusTrove SDK.
+ * All mutations require a connected wallet; they throw if `address` is not set.
+ *
+ * @param filters - Optional filters to narrow the invoice list.
+ * @param filters.status - Filter by invoice status (e.g. `'pending'`, `'funded'`).
+ * @param filters.issuer - Filter by the issuer's Stellar public key.
+ *
+ * @returns An object containing:
+ *   - `invoices` — Array of invoices matching the current filters (defaults to `[]`).
+ *   - `isLoading` — `true` while the invoice list is being fetched.
+ *   - `error` — Fetch error, or `null` if no error.
+ *   - `refetch` — Function to manually re-trigger the invoice list query.
+ *   - `createInvoice` — Async mutation: create a new invoice off-chain.
+ *   - `isCreating` / `createError` — State for the create mutation.
+ *   - `listInvoice` — Async mutation: list an invoice for financing on-chain.
+ *   - `isListing` / `listError` — State for the list mutation.
+ *   - `fundInvoice` — Async mutation: fund a listed invoice via the pool contract.
+ *   - `isFunding` / `fundError` — State for the fund mutation.
+ *   - `shipInvoice` — Async mutation: mark an invoice as shipped on-chain.
+ *   - `isShipping` / `shipError` — State for the ship mutation.
+ *   - `confirmDelivery` — Async mutation: confirm delivery of a shipped invoice.
+ *   - `isConfirming` / `confirmError` — State for the confirm mutation.
+ *   - `repayInvoice` — Async mutation: repay a funded invoice on-chain.
+ *   - `isRepaying` / `repayError` — State for the repay mutation.
+ *   - `defaultInvoice` — Async mutation: trigger default on an overdue invoice.
+ *   - `isDefaulting` / `defaultError` — State for the default mutation.
+ *
+ * @throws On-chain mutations throw `Error('Wallet not connected')` when `address` is absent.
+ *
+ * @example
+ * const { invoices, isLoading, createInvoice, isCreating } = useInvoices({ status: 'pending' });
+ */
 export function useInvoices(filters?: { status?: string; issuer?: string }) {
   const queryClient = useQueryClient();
   const { address } = useWalletStore();
@@ -132,6 +167,21 @@ export function useInvoices(filters?: { status?: string; issuer?: string }) {
   };
 }
 
+/**
+ * Custom hook for fetching a single invoice by its ID.
+ *
+ * @param id - The unique identifier of the invoice to fetch. The query is
+ *   skipped (disabled) when `id` is an empty string.
+ *
+ * @returns An object containing:
+ *   - `invoice` — The fetched invoice object, or `undefined` if not yet loaded.
+ *   - `isLoading` — `true` while the invoice is being fetched.
+ *   - `error` — Fetch error, or `null` if none.
+ *   - `refetch` — Function to manually re-trigger the invoice query.
+ *
+ * @example
+ * const { invoice, isLoading, error } = useInvoice(invoiceId);
+ */
 export function useInvoice(id: string) {
   const invoiceQuery = useQuery({
     queryKey: ['invoice', id],

--- a/apps/web/hooks/usePool.ts
+++ b/apps/web/hooks/usePool.ts
@@ -5,6 +5,33 @@ import { useWalletStore } from '@/store/wallet';
 
 const poolContractID = process.env.NEXT_PUBLIC_POOL_CONTRACT_ID || '';
 
+/**
+ * Custom hook for interacting with the TrusTrove liquidity pool contract.
+ *
+ * Provides pool statistics, the connected wallet's LP position, and mutations
+ * for depositing and withdrawing liquidity. All on-chain mutations require a
+ * connected wallet.
+ *
+ * @returns An object containing:
+ *   - `stats` — Global pool statistics (TVL, yield, utilisation), or `undefined` while loading.
+ *   - `isStatsLoading` — `true` while pool stats are being fetched.
+ *   - `statsError` — Fetch error for pool stats, or `null` if none.
+ *   - `refetchStats` — Function to manually re-trigger the pool stats query.
+ *   - `position` — The connected wallet's LP position (shares, claimable yield), or `undefined`.
+ *   - `isPositionLoading` — `true` while the LP position is being fetched.
+ *   - `positionError` — Fetch error for the LP position, or `null` if none.
+ *   - `refetchPosition` — Function to manually re-trigger the LP position query.
+ *   - `deposit` — Async mutation: deposit USDC into the pool and receive LP shares.
+ *   - `isDepositing` / `depositError` — State for the deposit mutation.
+ *   - `withdraw` — Async mutation: redeem LP shares for USDC from the pool.
+ *   - `isWithdrawing` / `withdrawError` — State for the withdraw mutation.
+ *
+ * @throws On-chain mutations throw `Error('Wallet not connected')` when `address` is absent.
+ *   The LP position query is disabled (skipped) when no wallet is connected.
+ *
+ * @example
+ * const { stats, position, deposit, isDepositing, withdraw } = usePool();
+ */
 export function usePool() {
   const queryClient = useQueryClient();
   const { address } = useWalletStore();
@@ -20,6 +47,13 @@ export function usePool() {
     enabled: !!address,
   });
 
+  /**
+   * Deposits USDC into the pool on behalf of the connected wallet.
+   *
+   * @param amount - Amount of USDC to deposit, expressed as a `bigint` in the token's
+   *   smallest unit (stroops for Stellar).
+   * @throws `Error('Wallet not connected')` if no wallet address is available.
+   */
   const depositMutation = useMutation({
     mutationFn: async ({ amount }: { amount: bigint }) => {
       if (!address) throw new Error('Wallet not connected');
@@ -32,6 +66,12 @@ export function usePool() {
     },
   });
 
+  /**
+   * Withdraws USDC from the pool by redeeming LP shares.
+   *
+   * @param shares - Number of LP shares to redeem, expressed as a `bigint`.
+   * @throws `Error('Wallet not connected')` if no wallet address is available.
+   */
   const withdrawMutation = useMutation({
     mutationFn: async ({ shares }: { shares: bigint }) => {
       if (!address) throw new Error('Wallet not connected');

--- a/apps/web/hooks/useWallet.ts
+++ b/apps/web/hooks/useWallet.ts
@@ -2,11 +2,39 @@ import { useState } from 'react';
 import { useWalletStore } from '@/store/wallet';
 import { connectFreighter } from '@/lib/freighter';
 
+/**
+ * Custom hook for managing Stellar wallet connection via Freighter.
+ *
+ * Provides wallet state and actions to connect or disconnect a Freighter wallet.
+ * Connection defaults to the testnet network.
+ *
+ * @returns An object containing:
+ *   - `address` — The connected wallet's public key, or `null` if not connected.
+ *   - `connected` — Whether a wallet is currently connected.
+ *   - `network` — The active network identifier (e.g. `'testnet'`).
+ *   - `connectWallet` — Async function that opens Freighter and connects the wallet.
+ *   - `disconnectWallet` — Function that disconnects the current wallet.
+ *   - `loading` — `true` while a connection attempt is in progress.
+ *   - `error` — Error message string if the last connection attempt failed, otherwise `null`.
+ *
+ * @throws Will catch errors from Freighter and surface them via the `error` return value
+ *   rather than throwing to the caller.
+ *
+ * @example
+ * const { address, connected, connectWallet, disconnectWallet, loading, error } = useWallet();
+ */
 export function useWallet() {
   const { address, connected, network, connect, disconnect } = useWalletStore();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  /**
+   * Initiates a Freighter wallet connection.
+   *
+   * Sets `loading` to `true` during the attempt. On success, stores the wallet
+   * address and defaults the network to `'testnet'`. On failure, stores the error
+   * message and calls `disconnect` to ensure a clean state.
+   */
   const connectWallet = async () => {
     setLoading(true);
     setError(null);
@@ -23,6 +51,9 @@ export function useWallet() {
     }
   };
 
+  /**
+   * Disconnects the currently connected wallet by clearing wallet state from the store.
+   */
   const disconnectWallet = () => {
     disconnect();
   };


### PR DESCRIPTION
Closes #16

## Summary

Adds comprehensive JSDoc comments to all four custom React hooks in `apps/web/hooks/`, addressing the documentation gap identified in issue #16.

## Changes

- **`useWallet.ts`** — Added top-level JSDoc with `@returns` descriptions for all 7 return values (`address`, `connected`, `network`, `connectWallet`, `disconnectWallet`, `loading`, `error`), a `@throws` note, and a `@example`. Added inline JSDoc to `connectWallet` and `disconnectWallet`.
- **`useAuth.ts`** — Added top-level JSDoc documenting the SEP-10 three-step flow, all 6 return values, `@throws`, and `@example`. Added inline JSDoc to `login` and `logout`.
- **`useInvoices.ts`** — Added top-level JSDoc to `useInvoices` with `@param filters`, all 18 return values (query state + 7 mutations × loading/error), `@throws`, and `@example`. Added top-level JSDoc to `useInvoice` with `@param id`, all 4 return values, and `@example`.
- **`usePool.ts`** — Added top-level JSDoc with all 12 return values (stats, position, deposit, withdraw), `@throws`, and `@example`. Added inline JSDoc to `depositMutation` and `withdrawMutation` documenting their `bigint` parameters.

## Format

Each export follows the pattern requested in the issue:
```
one-line summary
@param for each parameter
@returns description of each returned value
@throws for error cases
@example usage snippet
```