### PR TITLE
feat: migrate database to Neon Serverless Postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,11 @@ NEXT_PUBLIC_ESCROW_CONTRACT_ID=CAJWGUKDTTC3SKN4RAAY72J4DVIIYSCFHX6GIMNTT22ABMISJ
 NEXT_PUBLIC_USDC_ISSUER=GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
 NEXT_PUBLIC_USDC_ASSET_CODE=USDC
 
-# ── Indexer / API ────────────────────────────────────────────────────────────
-DATABASE_URL=postgresql://postgres:postgres@localhost:5432/trusttrove
+# ── Neon Postgres (Serverless DB) ─────────────────────────────────────────────
+# Get these values from: neonctl env pull
+# Or set in your deployment: Render → Environment Variables, Vercel → Environment Variables
+DATABASE_URL=postgresql://neondb_owner:***@ep-lively-poetry-atfrked0-pooler.c-9.us-east-1.aws.neon.tech/neondb?sslmode=require
+DATABASE_URL_UNPOOLED=postgresql://neondb_owner:***@ep-lively-poetry-atfrked0.c-9.us-east-1.aws.neon.tech/neondb?sslmode=require
 API_PORT=8080
 INDEXER_POLL_INTERVAL_MS=5000
 

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ pnpm-debug.log*
 *.sw?
 .DS_Store
 Thumbs.db
+.neon

--- a/docs/developer-guide/environment-variables.md
+++ b/docs/developer-guide/environment-variables.md
@@ -1,17 +1,39 @@
 # Environment Variables
 
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `NEXT_PUBLIC_STELLAR_NETWORK` | Network name | `testnet` |
-| `NEXT_PUBLIC_HORIZON_URL` | Horizon REST API endpoint | `https://horizon-testnet.stellar.org` |
-| `NEXT_PUBLIC_SOROBAN_RPC_URL` | Soroban RPC endpoint | `https://soroban-testnet.stellar.org` |
-| `NEXT_PUBLIC_NETWORK_PASSPHRASE` | Stellar network passphrase | `Test SDF Network ; September 2015` |
-| `NEXT_PUBLIC_REGISTRY_CONTRACT_ID` | Deployed registry contract address | `CABG...` |
-| `NEXT_PUBLIC_INVOICE_CONTRACT_ID` | Deployed invoice contract address | `CA4O...` |
-| `NEXT_PUBLIC_ESCROW_CONTRACT_ID` | Deployed escrow contract address | `CAJW...` |
-| `NEXT_PUBLIC_POOL_CONTRACT_ID` | Deployed pool contract address | `CAKE...` |
-| `NEXT_PUBLIC_USDC_ISSUER` | USDC issuer on Stellar testnet | `GBBD...` |
-| `NEXT_PUBLIC_API_URL` | Indexer API base URL | `https://trusttrove-app.onrender.com` |
-| `DATABASE_URL` | PostgreSQL connection string | `postgresql://user:pass@host/db` |
-| `API_PORT` | Indexer HTTP port | `8080` |
-| `JWT_SECRET` | Secret for JWT signing | `your-secret-here` |
+| Variable | Where needed | Description | Example |
+|----------|-------------|-------------|---------|
+| `NEXT_PUBLIC_STELLAR_NETWORK` | Frontend + Backend | Network name | `testnet` |
+| `NEXT_PUBLIC_HORIZON_URL` | Frontend + Backend | Horizon REST API endpoint | `https://horizon-testnet.stellar.org` |
+| `NEXT_PUBLIC_SOROBAN_RPC_URL` | Frontend + Backend | Soroban RPC endpoint | `https://soroban-testnet.stellar.org` |
+| `NEXT_PUBLIC_NETWORK_PASSPHRASE` | Frontend + Backend | Stellar network passphrase | `Test SDF Network ; September 2015` |
+| `NEXT_PUBLIC_REGISTRY_CONTRACT_ID` | Frontend + Backend | Deployed registry contract address | `CABG...` |
+| `NEXT_PUBLIC_INVOICE_CONTRACT_ID` | Frontend + Backend | Deployed invoice contract address | `CA4O...` |
+| `NEXT_PUBLIC_ESCROW_CONTRACT_ID` | Frontend + Backend | Deployed escrow contract address | `CAJW...` |
+| `NEXT_PUBLIC_POOL_CONTRACT_ID` | Frontend + Backend | Deployed pool contract address | `CAKE...` |
+| `NEXT_PUBLIC_USDC_ISSUER` | Frontend + Backend | USDC issuer on Stellar testnet | `GBBD...` |
+| `NEXT_PUBLIC_USDC_ASSET_CODE` | Frontend + Backend | USDC asset code | `USDC` |
+| `NEXT_PUBLIC_INDEXER_API_URL` | Frontend only | Indexer API base URL | `http://localhost:8080` |
+| `DATABASE_URL` | Backend only | Neon pooled connection string | `postgresql://user:pass@host/db?sslmode=require` |
+| `DATABASE_URL_UNPOOLED` | Backend only | Neon direct connection string | `postgresql://user:pass@host/db?sslmode=require` |
+| `API_PORT` | Backend only | Indexer HTTP port (fallback: `PORT`) | `8080` |
+| `INDEXER_POLL_INTERVAL_MS` | Backend only | Soroban event poll interval | `5000` |
+| `JWT_SECRET` | Backend only | Secret for JWT signing | `your-secret-here` |
+| `JWT_EXPIRY_HOURS` | Backend only | JWT token expiry | `24` |
+
+## Source of truth
+
+- **Local dev (backend):** Root `.env` + `.env.local` (loaded by godotenv, `.env.local` secrets take precedence)
+- **Local dev (frontend):** `apps/web/.env.local` (loaded by Next.js)
+- **Production (backend):** Render dashboard → Environment Variables
+- **Production (frontend):** Vercel dashboard → Environment Variables
+
+## Database
+
+The project uses **Neon Serverless Postgres** for the database. The connection string is managed via `neonctl`:
+
+```bash
+# Pull latest Neon env vars into .env.local
+npx neonctl env pull
+```
+
+This updates `DATABASE_URL` and `DATABASE_URL_UNPOOLED` with the correct credentials. Never hardcode these in `.env` or commit them to git.

--- a/indexer/config/config.go
+++ b/indexer/config/config.go
@@ -50,6 +50,9 @@ func LoadConfig() (*Config, error) {
 
 	apiPort := os.Getenv("API_PORT")
 	if apiPort == "" {
+		apiPort = os.Getenv("PORT") // Render provides PORT automatically
+	}
+	if apiPort == "" {
 		apiPort = "8080"
 	}
 


### PR DESCRIPTION
## Summary

Migrates the project's database from local PostgreSQL to **Neon Serverless Postgres**.

## Changes

### Backend (Go indexer)
- **indexer/config/config.go**: Added fallback to Render's `PORT` env var — this is why the backend was failing on Render (was hardcoded to `API_PORT` / 8080)
- **.env.example**: Updated with Neon connection string (secrets redacted)

### Frontend (Next.js)
- **apps/web/.env.local**: Created with all `NEXT_PUBLIC_*` vars for local dev (gitignored)

### Neon Setup
- Project `weathered-bird-80361975` linked via `.neon` (gitignored)
- Database migration ran on Neon: `invoices`, `pool_snapshots`, `events_log` tables created
- `.env.local` populated via `neonctl env pull`

### Docs
- **docs/developer-guide/environment-variables.md**: Expanded with Neon info, distinction between backend/frontend vars, and deployment guidance

### Chores
- **.gitignore**: Added `.neon` to ignore list
- **package-lock.json**: Removed (project uses pnpm)

## Deployment Steps

### Render (backend)
Set these env vars in Render Dashboard → Environment Variables:
- `DATABASE_URL` = Neon pooled connection string
- All `NEXT_PUBLIC_*` vars (Stellar network, contract IDs, USDC)

No need to set `API_PORT` — the backend now falls back to Render's `PORT`.

### Vercel (frontend)
Set these env vars in Vercel Dashboard → Environment Variables:
- `NEXT_PUBLIC_INDEXER_API_URL` = `https://your-render-backend.onrender.com`
- All `NEXT_PUBLIC_*` vars (Stellar network, contract IDs, USDC)

---

Closes: #(issue if any)