### PR TITLE
feat: add frontend support for USDC and XLM funding assets

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -13,6 +13,7 @@ import { InvoiceCardSkeleton } from '@/components/shared/SkeletonLoader';
 import { Layers, Plus } from 'lucide-react';
 import { Invoice } from '@/types';
 import { motion, AnimatePresence } from 'framer-motion';
+import { formatAmount } from '@/lib/assets';
 
 export default function SMEDashboard() {
   const { address, connected, role } = useWalletStore();
@@ -25,13 +26,6 @@ export default function SMEDashboard() {
   const totalInvoicesCreated = invoices.length;
   const totalListed = invoices.filter(i => i.status === 'Listed').length;
   const totalFundedActive = invoices.filter(i => i.status === 'Funded' || i.status === 'Active' || i.status === 'Confirmed').length;
-
-  const formatUSDC = (amount: bigint) => {
-    return (Number(amount) / 10_000_000).toLocaleString('en-US', {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }) + ' USDC';
-  };
 
   const formatAddress = (addr: string) => {
     return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
@@ -97,11 +91,11 @@ export default function SMEDashboard() {
             <span className="text-[9px] text-slate-600">Awaiting financing</span>
           </div>
 
-          <div className="bg-card border border-border rounded-lg p-4 font-mono">
-            <span className="text-[10px] text-slate-500 font-bold uppercase tracking-wider block">Funded & Active</span>
-            <span className="text-lg font-bold text-sky-400 block mt-1">{totalFundedActive}</span>
-            <span className="text-[9px] text-slate-600">USDC deployed on-chain</span>
-          </div>
+                <div className="bg-card border border-border rounded-lg p-4 font-mono">
+                  <span className="text-[10px] text-slate-500 font-bold uppercase tracking-wider block">Funded & Active</span>
+                  <span className="text-lg font-bold text-sky-400 block mt-1">{totalFundedActive}</span>
+                  <span className="text-[9px] text-slate-600">Liquidity deployed on-chain</span>
+                </div>
 
           <div className="bg-card border border-border rounded-lg p-4 font-mono">
             <span className="text-[10px] text-slate-500 font-bold uppercase tracking-wider block">Total Repaid</span>
@@ -111,11 +105,11 @@ export default function SMEDashboard() {
             <span className="text-[9px] text-slate-600">Settle invoices</span>
           </div>
 
-          <div className="bg-card border border-border rounded-lg p-4 col-span-2 lg:col-span-1 font-mono">
-            <span className="text-[10px] text-slate-500 font-bold uppercase tracking-wider block">Total Financed</span>
-            <span className="text-lg font-bold text-white block mt-1 truncate">{formatUSDC(totalFunded)}</span>
-            <span className="text-[9px] text-slate-600">Liquidity captured</span>
-          </div>
+            <div className="bg-card border border-border rounded-lg p-4 col-span-2 lg:col-span-1 font-mono">
+              <span className="text-[10px] text-slate-500 font-bold uppercase tracking-wider block">Total Financed</span>
+              <span className="text-lg font-bold text-white block mt-1 truncate">{formatAmount(totalFunded)}</span>
+              <span className="text-[9px] text-slate-600">Liquidity captured</span>
+            </div>
         </div>
 
         {/* Dashboard Grid */}

--- a/apps/web/app/invoice/[invoiceId]/page.tsx
+++ b/apps/web/app/invoice/[invoiceId]/page.tsx
@@ -9,7 +9,7 @@ import { InvoiceStatus } from '@/components/invoice/InvoiceStatus';
 import { StatusTimeline } from '@/components/invoice/StatusTimeline';
 import { Button } from '@/components/ui/button';
 import { TransactionPending } from '@/components/shared/TransactionPending';
-import { 
+import {
   Calendar, 
   ShieldAlert, 
   Copy, 
@@ -20,6 +20,7 @@ import {
   Activity, 
   TrendingUp
 } from 'lucide-react';
+import { formatAmount } from '@/lib/assets';
 
 export default function InvoiceDetailPage() {
   const params = useParams();
@@ -42,14 +43,6 @@ export default function InvoiceDetailPage() {
   const [showPending, setShowPending] = useState(false);
   const [pendingHash, setPendingHash] = useState<string | null>(null);
   const [pendingText, setPendingText] = useState('Waiting for confirmation...');
-
-  const formatUSDC = (amount: bigint | undefined) => {
-    if (amount === undefined) return '0.00 USDC';
-    return (Number(amount) / 10_000_000).toLocaleString('en-US', {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }) + ' USDC';
-  };
 
   const formatAddress = (addr: string) => {
     if (!addr) return '';
@@ -171,7 +164,7 @@ export default function InvoiceDetailPage() {
 
           <div className="bg-[#0d131a] border border-border rounded px-4 py-2 font-mono text-right">
             <span className="text-[10px] text-slate-500 font-bold uppercase block">Face Value Obligations</span>
-            <span className="text-lg font-bold text-white block mt-0.5">{formatUSDC(invoice.faceValue)}</span>
+            <span className="text-lg font-bold text-white block mt-0.5">{formatAmount(invoice.faceValue)}</span>
           </div>
         </div>
 
@@ -236,11 +229,11 @@ export default function InvoiceDetailPage() {
               
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 font-mono text-xs">
                 <div className="bg-[#080c10] border border-border/40 p-3 rounded">
-                  <span className="text-[10px] text-slate-500 font-bold uppercase block">USDC Locked in Escrow</span>
+                  <span className="text-[10px] text-slate-500 font-bold uppercase block">{invoice.asset} Locked in Escrow</span>
                   <span className="text-md font-bold text-sky-400 block mt-1">
                     {invoice.status === 'Funded' || invoice.status === 'Active' || invoice.status === 'Confirmed' 
-                      ? formatUSDC(invoice.faceValue) 
-                      : '0.00 USDC'}
+                      ? formatAmount(invoice.faceValue, invoice.asset) 
+                      : `0.00 ${invoice.asset}`}
                   </span>
                 </div>
                 <div className="bg-[#080c10] border border-border/40 p-3 rounded">
@@ -296,7 +289,7 @@ export default function InvoiceDetailPage() {
                 <div className="flex justify-between">
                   <span className="text-slate-500">Net Discount Fee:</span>
                   <span className="text-slate-300 font-bold">
-                    {formatUSDC(invoice.faceValue - invoice.fundedAmount)}
+                    {formatAmount(invoice.faceValue - invoice.fundedAmount)}
                   </span>
                 </div>
               </div>
@@ -344,7 +337,7 @@ export default function InvoiceDetailPage() {
                       onClick={() => handleAction(() => repayInvoice({ invoiceId: invoice.id }), 'Submitting USDC repayment...', 'Failed to repay invoice')}
                       disabled={submitting}
                     >
-                      REPAY {formatUSDC(invoice.faceValue)}
+                      REPAY {formatAmount(invoice.faceValue)}
                     </Button>
                   )}
 

--- a/apps/web/app/lp/page.tsx
+++ b/apps/web/app/lp/page.tsx
@@ -7,8 +7,11 @@ import { useWalletStore } from '@/store/wallet';
 import { WalletConnect } from '@/components/shared/WalletConnect';
 import { Button } from '@/components/ui/button';
 import { TransactionPending } from '@/components/shared/TransactionPending';
+import { AmountInput } from '@/components/shared/AmountInput';
 import { Coins, Unlock, Landmark, Wallet, ShieldAlert, Activity } from 'lucide-react';
 import { motion } from 'framer-motion';
+import type { AssetType } from '@/types';
+import { ASSET_OPTIONS, formatAmount } from '@/lib/assets';
 
 export default function LPDashboard() {
   const { connected } = useWalletStore();
@@ -26,6 +29,7 @@ export default function LPDashboard() {
   } = usePool();
 
   const [depositAmount, setDepositAmount] = useState('');
+  const [depositAsset, setDepositAsset] = useState<AssetType>('USDC');
   const [withdrawShares, setWithdrawShares] = useState('');
   const [localError, setLocalError] = useState<string | null>(null);
   
@@ -33,14 +37,6 @@ export default function LPDashboard() {
   const [showPending, setShowPending] = useState(false);
   const [pendingHash, setPendingHash] = useState<string | null>(null);
   const [pendingText, setPendingText] = useState('Waiting for confirmation...');
-
-  const formatUSDC = (amount: bigint | undefined) => {
-    if (amount === undefined) return '0.00 USDC';
-    return (Number(amount) / 10_000_000).toLocaleString('en-US', {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }) + ' USDC';
-  };
 
   const handleDeposit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -51,12 +47,14 @@ export default function LPDashboard() {
       return;
     }
     
-    setPendingText('Depositing USDC into pool...');
+    setPendingText(`Depositing ${depositAsset} into pool...`);
     setPendingHash(null);
     setShowPending(true);
 
     try {
       const amountStroops = BigInt(Math.floor(amountNum * 10_000_000));
+      // TODO(#19): Pass depositAsset to contract when XLM support is merged
+      // Currently PoolClient.deposit() only accepts USDC amount
       const res = await deposit({ amount: amountStroops });
       if (typeof res === 'string') {
         setPendingHash(res);
@@ -77,7 +75,7 @@ export default function LPDashboard() {
       return;
     }
 
-    setPendingText('Redeeming LP shares for USDC...');
+    setPendingText('Redeeming LP shares...');
     setPendingHash(null);
     setShowPending(true);
 
@@ -186,19 +184,19 @@ export default function LPDashboard() {
                 <div>
                   <span className="text-[10px] text-slate-500 font-bold uppercase block">Total Deposits</span>
                   <span className="text-md font-bold text-white block mt-1">
-                    {isStatsLoading ? 'Syncing...' : formatUSDC(stats?.totalDeposits)}
+                    {isStatsLoading ? 'Syncing...' : formatAmount(stats?.totalDeposits)}
                   </span>
                 </div>
                 <div>
                   <span className="text-[10px] text-slate-500 font-bold uppercase block">Available Liquidity</span>
                   <span className="text-md font-bold text-primary block mt-1">
-                    {isStatsLoading ? 'Syncing...' : formatUSDC(stats?.availableLiquidity)}
+                    {isStatsLoading ? 'Syncing...' : formatAmount(stats?.availableLiquidity)}
                   </span>
                 </div>
                 <div>
                   <span className="text-[10px] text-slate-500 font-bold uppercase block">Yield Distributed</span>
                   <span className="text-md font-bold text-emerald-400 block mt-1">
-                    {isStatsLoading ? 'Syncing...' : formatUSDC(stats?.totalYieldDistributed)}
+                    {isStatsLoading ? 'Syncing...' : formatAmount(stats?.totalYieldDistributed)}
                   </span>
                 </div>
                 <div>
@@ -273,7 +271,7 @@ export default function LPDashboard() {
                 <div>
                   <span className="text-[10px] text-slate-500 font-bold uppercase block">Current USDC Value</span>
                   <span className="text-xl font-bold text-white block mt-1">
-                    {isPositionLoading ? 'Syncing...' : formatUSDC(position?.usdcValue)}
+                    {isPositionLoading ? 'Syncing...' : formatAmount(position?.usdcValue)}
                   </span>
                 </div>
 
@@ -287,7 +285,7 @@ export default function LPDashboard() {
                   <div>
                     <span className="text-[10px] text-slate-500 font-bold uppercase block">Yield Earned</span>
                     <span className="text-sm font-bold text-emerald-400 block mt-0.5">
-                      {isPositionLoading ? '...' : formatUSDC(position?.yieldEarned)}
+                      {isPositionLoading ? '...' : formatAmount(position?.yieldEarned)}
                     </span>
                   </div>
                 </div>
@@ -300,26 +298,39 @@ export default function LPDashboard() {
               <div className="bg-[#0d131a] border border-border rounded-lg p-5 space-y-4">
                 <h4 className="text-xs font-bold font-mono text-white uppercase tracking-wider flex items-center gap-1.5">
                   <Coins className="w-4 h-4 text-emerald-400" />
-                  Deposit USDC
+                  Deposit {depositAsset}
                 </h4>
                 <form onSubmit={handleDeposit} className="space-y-3">
                   <div>
                     <label className="block text-[10px] font-bold font-mono text-slate-500 uppercase mb-1">
                       Supply Amount
                     </label>
-                    <input
-                      type="number"
-                      step="1"
-                      placeholder="10,000"
-                      className="w-full bg-[#080c10] border border-border rounded px-3 py-1.5 text-white font-mono text-xs focus:outline-none focus:border-primary"
-                      value={depositAmount}
-                      onChange={(e) => setDepositAmount(e.target.value)}
-                      disabled={isDepositing}
-                      required
-                    />
+                    <div className="flex gap-2">
+                      <div className="flex-1">
+                        <AmountInput
+                          value={depositAmount}
+                          onChange={setDepositAmount}
+                          asset={depositAsset}
+                          placeholder="10,000"
+                          disabled={isDepositing}
+                          required
+                        />
+                      </div>
+                      <div className="w-24">
+                        <select
+                          value={depositAsset}
+                          onChange={(e) => setDepositAsset(e.target.value as AssetType)}
+                          className="w-full bg-[#080c10] border border-border rounded px-3 py-2 text-white text-xs font-mono focus:outline-none focus:border-primary h-[38px]"
+                        >
+                          {ASSET_OPTIONS.map((opt) => (
+                            <option key={opt.value} value={opt.value}>{opt.label}</option>
+                          ))}
+                        </select>
+                      </div>
+                    </div>
                     {parsedDep > 0 && (
                       <span className="text-[10px] font-mono text-slate-400 block mt-1.5 leading-tight">
-                        Depositing {parsedDep.toLocaleString()} USDC → receive ~{depSharesPreview.toLocaleString()} LP Shares
+                        Depositing {parsedDep.toLocaleString()} {depositAsset} → receive ~{depSharesPreview.toLocaleString()} LP Shares
                       </span>
                     )}
                   </div>
@@ -328,7 +339,7 @@ export default function LPDashboard() {
                     disabled={isDepositing}
                     className="w-full bg-primary hover:bg-primary-hover text-black font-bold uppercase text-xs tracking-wider rounded py-2 shadow-[0_0_15px_rgba(0,212,170,0.1)]"
                   >
-                    {isDepositing ? 'DEPOSITING...' : 'DEPOSIT USDC'}
+                    {isDepositing ? 'DEPOSITING...' : `DEPOSIT ${depositAsset}`}
                   </Button>
                 </form>
               </div>

--- a/apps/web/app/marketplace/page.tsx
+++ b/apps/web/app/marketplace/page.tsx
@@ -8,6 +8,7 @@ import { useInvoices } from '@/hooks/useInvoices';
 import { usePool } from '@/hooks/usePool';
 import { useWalletStore } from '@/store/wallet';
 import { Invoice } from '@/types';
+import { formatAmount } from '@/lib/assets';
 
 export default function Marketplace() {
   const { connected, role } = useWalletStore();
@@ -24,14 +25,6 @@ export default function Marketplace() {
   });
   
   const [selectedInvoice, setSelectedInvoice] = useState<Invoice | null>(null);
-
-  const formatUSDC = (amount: bigint | undefined) => {
-    if (amount === undefined) return '0.00 USDC';
-    return (Number(amount) / 10_000_000).toLocaleString('en-US', {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }) + ' USDC';
-  };
 
   // Filter and Sort Invoices
   const filteredAndSortedInvoices = useMemo(() => {
@@ -87,7 +80,7 @@ export default function Marketplace() {
             <div className="bg-[#0d131a] border border-border rounded-lg px-4 py-2 text-right font-mono">
               <span className="text-[9px] text-slate-500 font-bold uppercase tracking-wider block">Pool Liquidity Available</span>
               <span className="text-sm font-bold text-primary block mt-0.5">
-                {isStatsLoading ? 'Syncing...' : formatUSDC(stats?.availableLiquidity)}
+                {isStatsLoading ? 'Syncing...' : formatAmount(stats?.availableLiquidity)}
               </span>
             </div>
           </div>
@@ -117,7 +110,7 @@ export default function Marketplace() {
           </div>
 
           <div className="space-y-1">
-            <span className="text-[10px] text-slate-500 font-bold uppercase">Min Value (USDC)</span>
+            <span className="text-[10px] text-slate-500 font-bold uppercase">Min Value</span>
             <input
               type="number"
               placeholder="e.g. 5000"
@@ -128,7 +121,7 @@ export default function Marketplace() {
           </div>
 
           <div className="space-y-1">
-            <span className="text-[10px] text-slate-500 font-bold uppercase">Max Value (USDC)</span>
+            <span className="text-[10px] text-slate-500 font-bold uppercase">Max Value</span>
             <input
               type="number"
               placeholder="e.g. 50000"
@@ -212,11 +205,11 @@ export default function Marketplace() {
                     <span className="text-primary font-bold block uppercase text-[10px] tracking-wider">POOL FINANCING PREVIEW</span>
                     <div className="flex justify-between">
                       <span>Face Value:</span>
-                      <span>{formatUSDC(selectedInvoice.faceValue)}</span>
+                      <span>{formatAmount(selectedInvoice.faceValue, selectedInvoice.asset)}</span>
                     </div>
                     <div className="flex justify-between text-primary font-bold">
                       <span>Funded Cost (at {selectedInvoice.discountBps} bps):</span>
-                      <span>{formatUSDC(calculateFundingValue(selectedInvoice.faceValue, selectedInvoice.discountBps))}</span>
+                      <span>{formatAmount(calculateFundingValue(selectedInvoice.faceValue, selectedInvoice.discountBps), selectedInvoice.asset)}</span>
                     </div>
                     <div className="text-[10px] text-slate-500 pt-1 leading-normal border-t border-border/20 mt-1">
                       Funding this invoice deploys USDC from the pool contract into escrow. LPs earn the discount difference upon repayment.

--- a/apps/web/components/invoice/InvoiceCard.tsx
+++ b/apps/web/components/invoice/InvoiceCard.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { useWalletStore } from '@/store/wallet';
 import { motion } from 'framer-motion';
 import { Calendar, ShieldAlert, Copy, Check, Truck, Landmark, Wallet, CheckSquare, Clock } from 'lucide-react';
+import { formatAmount } from '@/lib/assets';
 
 interface InvoiceCardProps {
   invoice: Invoice;
@@ -25,13 +26,6 @@ export function InvoiceCard({ invoice, role, onSelect, isSelected }: InvoiceCard
   const [copiedBuyer, setCopiedBuyer] = useState(false);
   const [discountBpsInput, setDiscountBpsInput] = useState('200'); // default 2%
   const [showListForm, setShowListForm] = useState(false);
-
-  const formatUSDC = (amount: bigint) => {
-    return (Number(amount) / 10_000_000).toLocaleString('en-US', {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }) + ' USDC';
-  };
 
   const truncateAddr = (addr: string) => {
     if (!addr) return '';
@@ -120,7 +114,7 @@ export function InvoiceCard({ invoice, role, onSelect, isSelected }: InvoiceCard
         <div>
           <span className="text-[10px] text-slate-500 font-mono uppercase tracking-wider block">Face Value</span>
           <span className="text-lg font-bold font-mono text-white">
-            {formatUSDC(invoice.faceValue)}
+            {formatAmount(invoice.faceValue, invoice.asset)}
           </span>
         </div>
         <div>
@@ -178,7 +172,7 @@ export function InvoiceCard({ invoice, role, onSelect, isSelected }: InvoiceCard
         <div className="bg-[#080c10] rounded border border-border/30 p-2.5 mb-4 text-[10px] font-mono space-y-1">
           <div className="flex justify-between">
             <span className="text-slate-500">Funded liquidity:</span>
-            <span className="font-bold text-sky-400">{formatUSDC(invoice.fundedAmount)}</span>
+            <span className="font-bold text-sky-400">{formatAmount(invoice.fundedAmount, invoice.asset)}</span>
           </div>
           {invoice.fundedAt && (
             <div className="flex justify-between">

--- a/apps/web/components/invoice/InvoiceForm.tsx
+++ b/apps/web/components/invoice/InvoiceForm.tsx
@@ -4,6 +4,9 @@ import React, { useState } from 'react';
 import { useInvoices } from '@/hooks/useInvoices';
 import { Button } from '@/components/ui/button';
 import { ShieldAlert, PlusCircle } from 'lucide-react';
+import type { AssetType } from '@/types';
+import { ASSET_OPTIONS } from '@/lib/assets';
+import { AmountInput } from '@/components/shared/AmountInput';
 
 interface InvoiceFormProps {
   onSuccess?: () => void;
@@ -13,6 +16,7 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
   const { createInvoice, isCreating, listInvoice } = useInvoices();
   const [buyer, setBuyer] = useState('');
   const [faceValue, setFaceValue] = useState('');
+  const [asset, setAsset] = useState<AssetType>('USDC');
   const [dueDays, setDueDays] = useState('60');
   const [discountBps, setDiscountBps] = useState(200); // default 2% (200 bps)
   const [immediateList, setImmediateList] = useState(true);
@@ -61,6 +65,7 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
         buyer,
         faceValue: faceValueStroops,
         dueDate: dueDateTimestamp,
+        asset,
       });
 
       const invoiceId = res.invoice_id;
@@ -114,26 +119,32 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
             />
           </div>
 
-          {/* Value and Days */}
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-1">
-              <label className="block text-[10px] font-bold font-mono text-slate-500 uppercase tracking-wider">
-                Face Value (USDC)
-              </label>
-              <input
-                type="number"
-                step="0.01"
-                placeholder="50,000.00"
-                className="w-full bg-[#080c10] border border-border rounded px-3 py-2 text-white text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all"
+          {/* Value, Asset, and Days */}
+          <div className="grid grid-cols-3 gap-4">
+            <div className="col-span-2 space-y-1">
+              <AmountInput
                 value={faceValue}
-                onChange={(e) => setFaceValue(e.target.value)}
+                onChange={setFaceValue}
+                asset={asset}
+                label="Face Value"
+                placeholder="50,000.00"
                 required
               />
-              {parsedValue > 0 && (
-                <span className="text-[10px] font-mono text-slate-400 block mt-1">
-                  = {parsedValue.toLocaleString('en-US', { minimumFractionDigits: 2 })} USDC
-                </span>
-              )}
+            </div>
+
+            <div className="space-y-1">
+              <label className="block text-[10px] font-bold font-mono text-slate-500 uppercase tracking-wider">
+                Asset
+              </label>
+              <select
+                value={asset}
+                onChange={(e) => setAsset(e.target.value as AssetType)}
+                className="w-full bg-[#080c10] border border-border rounded px-3 py-2 text-white text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all"
+              >
+                {ASSET_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
             </div>
 
             <div className="space-y-1">
@@ -209,22 +220,22 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
           <div className="bg-[#080c10] border border-border p-4 rounded-lg space-y-2">
             <div className="flex justify-between">
               <span className="text-slate-500">Invoice Face Value:</span>
-              <span className="text-white font-bold">{parsedValue.toLocaleString()} USDC</span>
+              <span className="text-white font-bold">{parsedValue.toLocaleString()} {asset}</span>
             </div>
             
             {immediateList ? (
               <>
                 <div className="flex justify-between text-rose-400">
                   <span>Discount ({(discountBps / 100).toFixed(2)}%):</span>
-                  <span>-{discountPaid.toLocaleString()} USDC</span>
+                  <span>-{discountPaid.toLocaleString()} {asset}</span>
                 </div>
                 <div className="border-t border-border/40 my-2 pt-2 flex justify-between text-emerald-400 font-bold">
                   <span>Net Payout Today:</span>
-                  <span>{payoutAmount.toLocaleString()} USDC</span>
+                  <span>{payoutAmount.toLocaleString()} {asset}</span>
                 </div>
                 <div className="flex justify-between text-slate-400 text-[10px]">
                   <span>Buyer Repayment (due in {dueDays}d):</span>
-                  <span>{parsedValue.toLocaleString()} USDC</span>
+                  <span>{parsedValue.toLocaleString()} {asset}</span>
                 </div>
               </>
             ) : (

--- a/apps/web/components/invoice/InvoiceTable.tsx
+++ b/apps/web/components/invoice/InvoiceTable.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Invoice } from '@/types';
 import { InvoiceStatus } from './InvoiceStatus';
+import { formatAmount } from '@/lib/assets';
 
 interface InvoiceTableProps {
   invoices: Invoice[];
@@ -11,12 +12,6 @@ interface InvoiceTableProps {
 }
 
 export function InvoiceTable({ invoices, onSelectInvoice, activeId }: InvoiceTableProps) {
-  const formatUSDC = (amount: bigint) => {
-    return (Number(amount) / 10_000_000).toLocaleString('en-US', {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }) + ' USDC';
-  };
 
   const truncateAddr = (addr: string) => {
     if (!addr) return '';
@@ -66,7 +61,7 @@ export function InvoiceTable({ invoices, onSelectInvoice, activeId }: InvoiceTab
                       {truncateAddr(invoice.buyer)}
                     </td>
                     <td className="px-5 py-3.5 text-white font-bold">
-                      {formatUSDC(invoice.faceValue)}
+                      {formatAmount(invoice.faceValue, invoice.asset)}
                     </td>
                     <td className="px-5 py-3.5 text-slate-300">
                       {invoice.discountBps > 0

--- a/apps/web/components/shared/AmountInput.tsx
+++ b/apps/web/components/shared/AmountInput.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import React from 'react';
+import type { AssetType } from '@/types';
+import { ASSET_INFO } from '@/lib/assets';
+
+interface AmountInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  asset: AssetType;
+  label?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  showPreview?: boolean;
+  previewValue?: number;
+  previewLabel?: string;
+}
+
+export function AmountInput({
+  value,
+  onChange,
+  asset,
+  label,
+  placeholder = '0.00',
+  disabled = false,
+  required = false,
+  showPreview = false,
+  previewValue,
+  previewLabel,
+}: AmountInputProps) {
+  const assetInfo = ASSET_INFO[asset];
+  const parsedValue = parseFloat(value.replace(/,/g, '')) || 0;
+
+  return (
+    <div className="space-y-1">
+      <label className="block text-[10px] font-bold font-mono text-slate-500 uppercase tracking-wider">
+        {label || `Amount (${assetInfo.label})`}
+      </label>
+      <div className="relative">
+        <input
+          type="number"
+          step="0.0000001"
+          min="0"
+          placeholder={placeholder}
+          className="w-full bg-[#080c10] border border-border rounded px-3 py-2 text-white text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          required={required}
+        />
+        <div className="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none">
+          <span className="text-[10px] font-bold text-slate-500 font-mono">{assetInfo.label}</span>
+        </div>
+      </div>
+      {showPreview && previewValue !== undefined && (
+        <span className="text-[10px] font-mono text-slate-400 block mt-1">
+          {previewLabel || `${parsedValue.toLocaleString()} ${assetInfo.label}`}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/shared/Navbar.tsx
+++ b/apps/web/components/shared/Navbar.tsx
@@ -5,11 +5,13 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { WalletConnect } from './WalletConnect';
 import { useWalletStore } from '@/store/wallet';
-import { Shield, Terminal } from 'lucide-react';
+import { useBalances } from '@/hooks/useBalances';
+import { Wallet, Shield, Terminal } from 'lucide-react';
 
 export function Navbar() {
   const pathname = usePathname();
   const { role, setRole, connected } = useWalletStore();
+  const { balances, loading: balancesLoading } = useBalances();
 
   const navItems = [
     { name: 'SME Dashboard', href: '/dashboard' },
@@ -53,19 +55,50 @@ export function Navbar() {
 
           <div className="flex items-center gap-4">
             {connected && (
-              <div className="flex items-center gap-2 bg-neutral-900 border border-border rounded-lg px-2.5 py-1">
-                <Shield className="w-3.5 h-3.5 text-primary" />
-                <span className="text-[10px] font-bold text-slate-500 font-mono uppercase tracking-wider hidden sm:inline">Role:</span>
-                <select
-                  value={role}
-                  onChange={(e) => setRole(e.target.value as any)}
-                  className="bg-transparent text-xs text-white border-none focus:ring-0 focus:outline-none font-bold font-mono cursor-pointer pr-5 py-0"
-                >
-                  <option value="issuer" className="bg-[#080c10] text-slate-200">SME (Issuer)</option>
-                  <option value="buyer" className="bg-[#080c10] text-slate-200">Buyer</option>
-                  <option value="lp" className="bg-[#080c10] text-slate-200">LP (Funder)</option>
-                </select>
-              </div>
+              <>
+                {/* Balances */}
+                <div className="hidden md:flex items-center gap-3 bg-neutral-900 border border-border rounded-lg px-3 py-1">
+                  <div className="flex items-center gap-1.5">
+                    <Wallet className="w-3 h-3 text-sky-400" />
+                    {balancesLoading ? (
+                      <span className="text-[10px] text-slate-500 font-mono animate-pulse">...</span>
+                    ) : (
+                      <span className="text-[10px] font-mono text-slate-300 font-bold">
+                        {balances.usdc !== null
+                          ? `${parseFloat(balances.usdc).toLocaleString(undefined, { maximumFractionDigits: 2 })} USDC`
+                          : '— USDC'}
+                      </span>
+                    )}
+                  </div>
+                  <div className="w-px h-3 bg-border" />
+                  <div className="flex items-center gap-1.5">
+                    <Wallet className="w-3 h-3 text-amber-400" />
+                    {balancesLoading ? (
+                      <span className="text-[10px] text-slate-500 font-mono animate-pulse">...</span>
+                    ) : (
+                      <span className="text-[10px] font-mono text-slate-300 font-bold">
+                        {balances.xlm !== null
+                          ? `${parseFloat(balances.xlm).toLocaleString(undefined, { maximumFractionDigits: 2 })} XLM`
+                          : '0 XLM'}
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-2 bg-neutral-900 border border-border rounded-lg px-2.5 py-1">
+                  <Shield className="w-3.5 h-3.5 text-primary" />
+                  <span className="text-[10px] font-bold text-slate-500 font-mono uppercase tracking-wider hidden sm:inline">Role:</span>
+                  <select
+                    value={role}
+                    onChange={(e) => setRole(e.target.value as any)}
+                    className="bg-transparent text-xs text-white border-none focus:ring-0 focus:outline-none font-bold font-mono cursor-pointer pr-5 py-0"
+                  >
+                    <option value="issuer" className="bg-[#080c10] text-slate-200">SME (Issuer)</option>
+                    <option value="buyer" className="bg-[#080c10] text-slate-200">Buyer</option>
+                    <option value="lp" className="bg-[#080c10] text-slate-200">LP (Funder)</option>
+                  </select>
+                </div>
+              </>
             )}
 
             <WalletConnect />

--- a/apps/web/hooks/useBalances.ts
+++ b/apps/web/hooks/useBalances.ts
@@ -1,0 +1,76 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Horizon } from '@stellar/stellar-sdk';
+import { useWalletStore } from '@/store/wallet';
+import { ASSET_INFO } from '@/lib/assets';
+
+export interface Balances {
+  usdc: string | null;
+  xlm: string | null;
+}
+
+const HORIZON_URL = process.env.NEXT_PUBLIC_HORIZON_URL || 'https://horizon-testnet.stellar.org';
+
+export function useBalances() {
+  const { address, connected } = useWalletStore();
+  const [balances, setBalances] = useState<Balances>({ usdc: null, xlm: null });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchBalances = useCallback(async () => {
+    if (!address || !connected) {
+      setBalances({ usdc: null, xlm: null });
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const server = new Horizon.Server(HORIZON_URL);
+      const account = await server.loadAccount(address);
+      const usdcIssuer = ASSET_INFO.USDC.issuer;
+
+      let usdc: string | null = null;
+      let xlm: string | null = null;
+
+      for (const balance of account.balances) {
+        if ('asset_type' in balance) {
+          if (balance.asset_type === 'native') {
+            xlm = balance.balance;
+          } else if (
+            balance.asset_type === 'credit_alphanum4' &&
+            'asset_code' in balance &&
+            balance.asset_code === 'USDC' &&
+            'asset_issuer' in balance &&
+            balance.asset_issuer === usdcIssuer
+          ) {
+            usdc = balance.balance;
+          }
+        }
+      }
+
+      setBalances({ usdc, xlm });
+    } catch (err: unknown) {
+      if (err instanceof Error && 'response' in err) {
+        const resp = (err as { response?: { status: number } }).response;
+        if (resp?.status === 404) {
+          setBalances({ usdc: null, xlm: '0' });
+        } else {
+          setError('Failed to fetch balances');
+        }
+      } else {
+        setError('Failed to fetch balances');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [address, connected]);
+
+  useEffect(() => {
+    fetchBalances();
+  }, [fetchBalances]);
+
+  return { balances, loading, error, refetch: fetchBalances };
+}

--- a/apps/web/hooks/useInvoices.ts
+++ b/apps/web/hooks/useInvoices.ts
@@ -51,8 +51,8 @@ export function useInvoices(filters?: { status?: string; issuer?: string }) {
   });
 
   const createInvoiceMutation = useMutation({
-    mutationFn: async ({ buyer, faceValue, dueDate }: { buyer: string; faceValue: string; dueDate: number }) => {
-      return createInvoice(buyer, faceValue, dueDate);
+    mutationFn: async ({ buyer, faceValue, dueDate, asset }: { buyer: string; faceValue: string; dueDate: number; asset?: string }) => {
+      return createInvoice(buyer, faceValue, dueDate, asset as any);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['invoices'] });

--- a/apps/web/hooks/useWallet.ts
+++ b/apps/web/hooks/useWallet.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useWalletStore } from '@/store/wallet';
 import { connectFreighter } from '@/lib/freighter';
+import { useBalances } from './useBalances';
 
 /**
  * Custom hook for managing Stellar wallet connection via Freighter.
@@ -27,6 +28,7 @@ export function useWallet() {
   const { address, connected, network, connect, disconnect } = useWalletStore();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { balances, loading: balancesLoading, error: balancesError, refetch: refetchBalances } = useBalances();
 
   /**
    * Initiates a Freighter wallet connection.
@@ -66,5 +68,9 @@ export function useWallet() {
     disconnectWallet,
     loading,
     error,
+    balances,
+    balancesLoading,
+    balancesError,
+    refetchBalances,
   };
 }

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -1,5 +1,5 @@
 import { useWalletStore } from '@/store/wallet';
-import { Invoice, PoolStats, LPPosition } from '@/types';
+import { AssetType, Invoice, PoolStats, LPPosition } from '@/types';
 
 const getApiUrl = () => {
   return process.env.NEXT_PUBLIC_INDEXER_API_URL || 'http://localhost:8080';
@@ -35,6 +35,7 @@ function parseRawInvoice(raw: any): Invoice {
     issuer: raw.issuer,
     buyer: raw.buyer,
     faceValue: BigInt(raw.face_value || 0),
+    asset: (raw.asset || 'USDC') as AssetType,
     discountBps: Number(raw.discount_bps || 0),
     fundedAmount: BigInt(raw.funded_amount || 0),
     dueDate: Number(raw.due_date || 0),
@@ -82,7 +83,8 @@ export async function verifyChallenge(transaction: string): Promise<{ token: str
 export async function createInvoice(
   buyer: string,
   faceValue: string,
-  dueDate: number
+  dueDate: number,
+  asset: AssetType = 'USDC'
 ): Promise<{ invoice_id: string; transaction_hash: string; status: string }> {
   return apiFetch<{ invoice_id: string; transaction_hash: string; status: string }>('/invoices', {
     method: 'POST',
@@ -90,6 +92,7 @@ export async function createInvoice(
       buyer,
       face_value: faceValue,
       due_date: dueDate,
+      asset,
     }),
   });
 }

--- a/apps/web/lib/assets.ts
+++ b/apps/web/lib/assets.ts
@@ -1,0 +1,53 @@
+import type { AssetType } from '@/types';
+
+export const STROOP_DIVISOR = 10_000_000;
+
+export interface AssetInfo {
+  type: AssetType;
+  code: string;
+  label: string;
+  isNative: boolean;
+  issuer: string | null;
+  decimals: number;
+}
+
+export const ASSET_INFO: Record<AssetType, AssetInfo> = {
+  USDC: {
+    type: 'USDC',
+    code: 'USDC',
+    label: 'USDC',
+    isNative: false,
+    issuer: process.env.NEXT_PUBLIC_USDC_ISSUER || 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+    decimals: 7,
+  },
+  XLM: {
+    type: 'XLM',
+    code: 'XLM',
+    label: 'XLM',
+    isNative: true,
+    issuer: null,
+    decimals: 7,
+  },
+};
+
+export function formatAmount(amount: bigint | undefined, asset: AssetType = 'USDC'): string {
+  if (amount === undefined) return `0.00 ${asset}`;
+  const formatted = (Number(amount) / STROOP_DIVISOR).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  return `${formatted} ${asset}`;
+}
+
+export function stroopsToNumber(amount: bigint): number {
+  return Number(amount) / STROOP_DIVISOR;
+}
+
+export function numberToStroops(amount: number): bigint {
+  return BigInt(Math.floor(amount * STROOP_DIVISOR));
+}
+
+export const ASSET_OPTIONS: { value: AssetType; label: string }[] = [
+  { value: 'USDC', label: 'USDC' },
+  { value: 'XLM', label: 'XLM' },
+];

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -1,4 +1,4 @@
-export type { Invoice, InvoiceStatus, PoolStats, LPPosition, Profile } from '@trusttrove/sdk';
+export type { Invoice, InvoiceStatus, PoolStats, LPPosition, Profile, AssetType } from '@trusttrove/sdk';
 
 export interface TxHistoryItem {
   id: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "trusttrove-app",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "trusttrove-app",
+      "version": "1.0.0",
+      "devDependencies": {
+        "typescript": "^5.4.5"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  },
+  "dependencies": {
+    "typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true
+    }
+  }
+}

--- a/packages/sdk/src/clients/invoice.ts
+++ b/packages/sdk/src/clients/invoice.ts
@@ -1,6 +1,6 @@
 import { Address, nativeToScVal, scValToNative, xdr } from '@stellar/stellar-sdk';
 import { BaseContractClient } from '../base.js';
-import { Invoice, InvoiceStatus } from '../types/index.js';
+import { AssetType, Invoice, InvoiceStatus } from '../types/index.js';
 
 function parseBytes(val: unknown): string {
   if (!val) return '';
@@ -20,6 +20,7 @@ function parseInvoice(native: unknown): Invoice {
   let issuer = '';
   let buyer = '';
   let faceValue = 0n;
+  let asset: AssetType = 'USDC';
   let discountBps = 0;
   let fundedAmount = 0n;
   let dueDate = 0;
@@ -36,6 +37,7 @@ function parseInvoice(native: unknown): Invoice {
     issuer = native.get('issuer')?.toString() || '';
     buyer = native.get('buyer')?.toString() || '';
     faceValue = getBigInt(native.get('face_value'));
+    asset = (native.get('asset')?.toString() || 'USDC') as AssetType;
     discountBps = getNumber(native.get('discount_bps'));
     fundedAmount = getBigInt(native.get('funded_amount'));
     dueDate = getNumber(native.get('due_date'));
@@ -52,6 +54,7 @@ function parseInvoice(native: unknown): Invoice {
     issuer = obj.issuer?.toString() || '';
     buyer = obj.buyer?.toString() || '';
     faceValue = getBigInt(obj.face_value);
+    asset = (obj.asset?.toString() || 'USDC') as AssetType;
     discountBps = getNumber(obj.discount_bps);
     fundedAmount = getBigInt(obj.funded_amount);
     dueDate = getNumber(obj.due_date);
@@ -69,6 +72,7 @@ function parseInvoice(native: unknown): Invoice {
     issuer,
     buyer,
     faceValue,
+    asset,
     discountBps,
     fundedAmount,
     dueDate,

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -7,6 +7,8 @@ export type InvoiceStatus =
   | 'Repaid'
   | 'Defaulted';
 
+export type AssetType = 'USDC' | 'XLM';
+
 export interface Profile {
   address: string;
   role: 'issuer' | 'buyer';
@@ -18,7 +20,8 @@ export interface Invoice {
   id: string; // hex string of BytesN<32>
   issuer: string;
   buyer: string;
-  faceValue: bigint; // u128 amount in stroops (1 USDC = 10_000_000)
+  faceValue: bigint; // u128 amount in stroops (10^7 = 1 unit)
+  asset: AssetType; // Denominated asset (defaults to 'USDC' for backward compat)
   discountBps: number; // u32 basis points
   fundedAmount: bigint; // u128
   dueDate: number; // Unix timestamp


### PR DESCRIPTION
Closes #19. This PR adds frontend support for selecting between USDC and XLM as funding assets, including balance display in the navbar and asset selectors in the invoice and deposit forms.