### PR TITLE
feat(indexer): add /stats endpoint aggregating protocol statistics

### DIFF
--- a/indexer/api/handlers.go
+++ b/indexer/api/handlers.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"trusttrove/indexer/config"
@@ -25,8 +26,11 @@ import (
 )
 
 type APIHandler struct {
-	cfg      *config.Config
-	serverKP *keypair.Full
+	cfg         *config.Config
+	serverKP    *keypair.Full
+	statsMu     sync.Mutex
+	statsData   *db.ProtocolStats
+	statsCached time.Time
 }
 
 func NewAPIHandler(cfg *config.Config) (*APIHandler, error) {
@@ -706,6 +710,33 @@ func (h *APIHandler) HandleGetInvoices(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(invoices)
+}
+
+// GET /stats
+func (h *APIHandler) HandleGetStats(w http.ResponseWriter, r *http.Request) {
+	h.statsMu.Lock()
+	if h.statsData != nil && time.Since(h.statsCached) < 30*time.Second {
+		data := h.statsData
+		h.statsMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(data)
+		return
+	}
+	h.statsMu.Unlock()
+
+	stats, err := db.GetProtocolStats(r.Context())
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to retrieve protocol stats: %s", err.Error()), http.StatusInternalServerError)
+		return
+	}
+
+	h.statsMu.Lock()
+	h.statsData = stats
+	h.statsCached = time.Now()
+	h.statsMu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(stats)
 }
 
 // GET /pool/stats

--- a/indexer/api/router.go
+++ b/indexer/api/router.go
@@ -91,6 +91,9 @@ func NewRouter(h *APIHandler) *chi.Mux {
 	r.Get("/auth", h.HandleGetAuth)
 	r.Post("/auth", h.HandlePostAuth)
 
+	// Public protocol stats (cached, no auth)
+	r.Get("/stats", h.HandleGetStats)
+
 	// Invoices and Pool routes
 	r.Get("/invoices/{id}", h.HandleGetInvoiceByID)
 	r.Get("/invoices", h.HandleGetInvoices)

--- a/indexer/db/queries.go
+++ b/indexer/db/queries.go
@@ -37,6 +37,45 @@ type DbPoolStats struct {
 	UpdatedAt             time.Time `json:"updated_at"`
 }
 
+type ProtocolStats struct {
+	TotalUSDCFinanced  string `json:"total_usdc_financed"`
+	ActiveInvoiceCount int    `json:"active_invoice_count"`
+	TotalInvoices      int    `json:"total_invoices"`
+	TotalRepaid        int    `json:"total_repaid"`
+	TotalDefaulted     int    `json:"total_defaulted"`
+	AverageYieldBps    int    `json:"average_yield_bps"`
+	PoolUtilizationBps int    `json:"pool_utilization_bps"`
+}
+
+func GetProtocolStats(ctx context.Context) (*ProtocolStats, error) {
+	query := `
+		SELECT
+			COALESCE(SUM(funded_amount) FILTER (WHERE status IN ('funded', 'shipped', 'confirmed', 'repaid')), 0)::TEXT AS total_usdc_financed,
+			COUNT(*) FILTER (WHERE status IN ('funded', 'shipped', 'confirmed')) AS active_invoice_count,
+			COUNT(*) AS total_invoices,
+			COUNT(*) FILTER (WHERE status = 'repaid') AS total_repaid,
+			COUNT(*) FILTER (WHERE status = 'defaulted') AS total_defaulted,
+			COALESCE(AVG(discount_bps) FILTER (WHERE status IN ('funded', 'shipped', 'confirmed', 'repaid')), 0)::INTEGER AS average_yield_bps,
+			COALESCE((SELECT utilization_rate_bps FROM pool_snapshots WHERE id = 1), 0) AS pool_utilization_bps
+		FROM invoices
+	`
+	row := Pool.QueryRow(ctx, query)
+	var stats ProtocolStats
+	err := row.Scan(
+		&stats.TotalUSDCFinanced,
+		&stats.ActiveInvoiceCount,
+		&stats.TotalInvoices,
+		&stats.TotalRepaid,
+		&stats.TotalDefaulted,
+		&stats.AverageYieldBps,
+		&stats.PoolUtilizationBps,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("queries: get protocol stats: %w", err)
+	}
+	return &stats, nil
+}
+
 func InsertInvoice(ctx context.Context, inv *DbInvoice) error {
 	query := `
 		INSERT INTO invoices (


### PR DESCRIPTION
- Add ProtocolStats struct and GetProtocolStats DB query
- Aggregate total_usdc_financed, active/total/repaid/defaulted invoice counts, average_yield_bps, and pool_utilization_bps from invoices + pool_snapshots
- Add HandleGetStats handler with 30-second in-memory cache
- Register GET /stats as a public route (no auth required)
- Return amounts as strings to preserve u128 precision

closes https://github.com/TrusTrove/TrusTrove-app/issues/13