### PR TITLE
feat(sdk): add retry logic for Soroban RPC calls on network timeout

### DIFF
--- a/packages/sdk/src/base.ts
+++ b/packages/sdk/src/base.ts
@@ -9,6 +9,58 @@ import {
 import { signTransaction } from '@stellar/freighter-api';
 import { getConfig, getSorobanServer } from './config.js';
 
+function isNetworkError(err: unknown): boolean {
+  if (err instanceof TypeError) return true;
+  const msg = err instanceof Error ? err.message.toLowerCase() : '';
+  return (
+    msg.includes('fetch') ||
+    msg.includes('network') ||
+    msg.includes('timeout') ||
+    msg.includes('abort') ||
+    msg.includes('econnrefused') ||
+    msg.includes('enotfound') ||
+    msg.includes('econnreset') ||
+    msg.includes('eai_again') ||
+    msg.includes('etimedout')
+  );
+}
+
+interface RetryOptions {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+}
+
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {}
+): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? 3;
+  const baseDelayMs = options.baseDelayMs ?? 1000;
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+
+      if (!isNetworkError(err) || attempt === maxAttempts) {
+        throw err;
+      }
+
+      const delay = baseDelayMs * Math.pow(2, attempt - 1);
+      console.warn(
+        `[SDK] RPC call failed (attempt ${attempt}/${maxAttempts}): ${err instanceof Error ? err.message : String(err)}. Retrying in ${delay}ms...`
+      );
+
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError;
+}
+
 export class BaseContractClient {
   protected contractId: string;
 
@@ -31,8 +83,8 @@ export class BaseContractClient {
   ): Promise<T> {
     const config = getConfig();
     const server = getSorobanServer();
-    const account = await server.getAccount(publicKey);
-    
+    const account = await withRetry(() => server.getAccount(publicKey));
+
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
       networkPassphrase: config.networkPassphrase,
@@ -41,16 +93,16 @@ export class BaseContractClient {
       .setTimeout(30)
       .build();
 
-    const sim = await server.simulateTransaction(tx);
+    const sim = await withRetry(() => server.simulateTransaction(tx));
     if (rpc.Api.isSimulationError(sim)) {
       throw new Error(`Simulation failed for ${method}: ${sim.error}`);
     }
-    
+
     const resultVal = (sim as rpc.Api.SimulateTransactionSuccessResponse).result?.retval;
     if (!resultVal) {
       throw new Error(`No return value from simulation for ${method}`);
     }
-    
+
     return parse(resultVal);
   }
 
@@ -61,8 +113,8 @@ export class BaseContractClient {
   ): Promise<string> {
     const config = getConfig();
     const server = getSorobanServer();
-    const account = await server.getAccount(publicKey);
-    
+    const account = await withRetry(() => server.getAccount(publicKey));
+
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
       networkPassphrase: config.networkPassphrase,
@@ -71,31 +123,32 @@ export class BaseContractClient {
       .setTimeout(30)
       .build();
 
-    const sim = await server.simulateTransaction(tx);
+    const sim = await withRetry(() => server.simulateTransaction(tx));
     if (rpc.Api.isSimulationError(sim)) {
       throw new Error(`Simulation failed for ${method}: ${sim.error}`);
     }
 
-    const prepared = await server.prepareTransaction(tx);
+    const prepared = await withRetry(() => server.prepareTransaction(tx));
     const signed = await signTransaction(prepared.toXDR(), {
       network: config.networkPassphrase === Networks.PUBLIC ? 'PUBLIC' : 'TESTNET',
       networkPassphrase: config.networkPassphrase,
       accountToSign: publicKey,
     });
 
-    const result = await server.sendTransaction(
-      TransactionBuilder.fromXDR(signed, config.networkPassphrase)
+    const result = await withRetry(() =>
+      server.sendTransaction(
+        TransactionBuilder.fromXDR(signed, config.networkPassphrase)
+      )
     );
 
     if (result.status === 'ERROR') {
       throw new Error(`Send failed for ${method}: ${result.errorResult?.toXDR()}`);
     }
 
-    // Poll for confirmation
-    let response = await server.getTransaction(result.hash);
+    let response = await withRetry(() => server.getTransaction(result.hash));
     while (response.status === rpc.Api.GetTransactionStatus.NOT_FOUND) {
       await new Promise(r => setTimeout(r, 1000));
-      response = await server.getTransaction(result.hash);
+      response = await withRetry(() => server.getTransaction(result.hash));
     }
 
     if (response.status === rpc.Api.GetTransactionStatus.FAILED) {


### PR DESCRIPTION
- Add withRetry utility with exponential backoff (1s, 2s, 4s)
- Add isNetworkError guard — only retry on network/timeout errors, never on contract logic or simulation errors
- Wrap all RPC calls (getAccount, simulateTransaction, prepareTransaction, sendTransaction, getTransaction) with withRetry
- Log each retry attempt with attempt number and error message

closes https://github.com/TrusTrove/TrusTrove-app/issues/2