### PR TITLE
feat(web): implement mobile-responsive invoice creation flow

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -199,18 +199,26 @@ export default function SMEDashboard() {
 
       {/* Create Invoice Dialog Modal */}
       {showCreateModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#080c10]/95 backdrop-blur-sm p-4">
-          <div className="w-full max-w-lg relative">
-            <button
-              onClick={() => setShowCreateModal(false)}
-              className="absolute -top-10 right-0 text-slate-500 hover:text-white font-bold font-mono text-xs uppercase"
-            >
-              [Close Esc]
-            </button>
-            <InvoiceForm onSuccess={() => {
-              setShowCreateModal(false);
-              setSelectedInvoice(null);
-            }} />
+        <div className="fixed inset-0 z-50 flex items-end md:items-center justify-center bg-[#080c10]/95 backdrop-blur-sm p-0 md:p-4">
+          <div
+            className="w-full max-w-lg relative bg-card border md:border-border rounded-t-2xl md:rounded-lg max-h-[92vh] md:max-h-[85vh] overflow-hidden flex flex-col shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between px-5 pt-4 pb-2 border-b border-border/40 shrink-0">
+              <span className="text-[10px] font-bold font-mono text-slate-500 uppercase tracking-wider">New Invoice</span>
+              <button
+                onClick={() => setShowCreateModal(false)}
+                className="text-slate-500 hover:text-white font-bold font-mono text-xs uppercase px-2 py-1 min-h-[44px] min-w-[44px] flex items-center justify-center"
+              >
+                [Close Esc]
+              </button>
+            </div>
+            <div className="overflow-y-auto overscroll-contain p-5 pt-3">
+              <InvoiceForm onSuccess={() => {
+                setShowCreateModal(false);
+                setSelectedInvoice(null);
+              }} />
+            </div>
           </div>
         </div>
       )}

--- a/apps/web/components/invoice/InvoiceForm.tsx
+++ b/apps/web/components/invoice/InvoiceForm.tsx
@@ -96,10 +96,23 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
   };
 
   return (
-    <div className="bg-card border border-border rounded-lg p-5">
+    <div className="space-y-5">
       <div className="flex items-center gap-2 mb-4 border-b border-border/40 pb-3">
-        <PlusCircle className="w-4 h-4 text-primary" />
+        <PlusCircle className="w-4 h-4 text-primary shrink-0" />
         <h2 className="text-sm font-bold font-mono tracking-wider uppercase text-white">Create trade Invoice</h2>
+      </div>
+
+      {/* Step Indicators */}
+      <div className="flex items-center gap-2 mb-5 px-1">
+        <div className={`flex items-center gap-1.5 ${step === 1 ? 'text-primary' : 'text-emerald-400'}`}>
+          <div className={`w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold font-mono border ${step === 1 ? 'bg-primary/20 border-primary text-primary' : 'bg-emerald-400/20 border-emerald-400 text-emerald-400'}`}>1</div>
+          <span className="text-[10px] font-bold font-mono uppercase tracking-wider">Terms</span>
+        </div>
+        <div className={`flex-1 h-px mx-1 ${step === 2 ? 'bg-emerald-400/50' : 'bg-border'}`} />
+        <div className={`flex items-center gap-1.5 ${step === 2 ? 'text-primary' : 'text-slate-500'}`}>
+          <div className={`w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold font-mono border ${step === 2 ? 'bg-primary/20 border-primary text-primary' : 'bg-slate-800 border-border text-slate-500'}`}>2</div>
+          <span className="text-[10px] font-bold font-mono uppercase tracking-wider">Sign</span>
+        </div>
       </div>
 
       {step === 1 ? (
@@ -112,7 +125,7 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
             <input
               type="text"
               placeholder="e.g. GBBD47IF6L... (Stellar Public Key)"
-              className="w-full bg-[#080c10] border border-border rounded px-3 py-2 text-white text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all"
+              className="w-full bg-[#080c10] border border-border rounded px-3 py-2.5 text-white text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all min-h-[44px]"
               value={buyer}
               onChange={(e) => setBuyer(e.target.value)}
               required
@@ -139,7 +152,7 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
               <select
                 value={asset}
                 onChange={(e) => setAsset(e.target.value as AssetType)}
-                className="w-full bg-[#080c10] border border-border rounded px-3 py-2 text-white text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all"
+                className="w-full bg-[#080c10] border border-border rounded px-3 py-2.5 text-white text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all min-h-[44px]"
               >
                 {ASSET_OPTIONS.map((opt) => (
                   <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -152,11 +165,13 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
                 Due Days
               </label>
               <input
-                type="number"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
                 placeholder="60"
-                className="w-full bg-[#080c10] border border-border rounded px-3 py-2 text-white text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all"
+                className="w-full bg-[#080c10] border border-border rounded px-3 py-2.5 text-white text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all min-h-[44px]"
                 value={dueDays}
-                onChange={(e) => setDueDays(e.target.value)}
+                onChange={(e) => setDueDays(e.target.value.replace(/\D/g, ''))}
                 required
               />
               <span className="text-[10px] font-mono text-slate-500 block mt-1">
@@ -178,7 +193,7 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
               step="10"
               value={discountBps}
               onChange={(e) => setDiscountBps(parseInt(e.target.value))}
-              className="w-full accent-primary bg-slate-900 h-1.5 rounded"
+              className="w-full accent-primary bg-slate-900 h-2 rounded cursor-pointer touch-pan-y"
             />
             <div className="flex justify-between text-[9px] text-slate-600 font-mono">
               <span>0.5% (50 bps)</span>
@@ -187,15 +202,15 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
           </div>
 
           {/* Immediate Listing option */}
-          <div className="flex items-center gap-2 pt-2">
+          <div className="flex items-center gap-3 pt-2">
             <input
               type="checkbox"
               id="immediateList"
-              className="rounded bg-[#080c10] border-border text-primary focus:ring-primary focus:ring-offset-0"
+              className="rounded bg-[#080c10] border-border text-primary focus:ring-primary focus:ring-offset-0 w-5 h-5 shrink-0 cursor-pointer"
               checked={immediateList}
               onChange={(e) => setImmediateList(e.target.checked)}
             />
-            <label htmlFor="immediateList" className="text-xs font-mono text-slate-400 cursor-pointer select-none">
+            <label htmlFor="immediateList" className="text-xs font-mono text-slate-400 cursor-pointer select-none py-2">
               List for immediate LP financing at creation
             </label>
           </div>
@@ -209,7 +224,7 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
 
           <Button
             type="submit"
-            className="w-full bg-primary hover:bg-primary-hover text-black font-bold uppercase tracking-wider text-xs rounded py-2.5 shadow-[0_0_15px_rgba(0,212,170,0.1)]"
+            className="w-full bg-primary hover:bg-primary-hover text-black font-bold uppercase tracking-wider text-xs rounded py-2.5 min-h-[44px] shadow-[0_0_15px_rgba(0,212,170,0.1)]"
           >
             REVIEW FINANCING TERMS
           </Button>
@@ -259,14 +274,14 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
 
           <div className="flex gap-2">
             <Button
-              className="flex-1 border border-border bg-transparent hover:bg-slate-900 text-slate-400 font-bold uppercase py-2"
+              className="flex-1 border border-border bg-transparent hover:bg-slate-900 text-slate-400 font-bold uppercase py-2 min-h-[44px]"
               onClick={() => setStep(1)}
               disabled={isCreating || isListing}
             >
               EDIT
             </Button>
             <Button
-              className="flex-1 bg-primary hover:bg-primary-hover text-black font-bold uppercase py-2 flex items-center justify-center gap-1.5 shadow-[0_0_15px_rgba(0,212,170,0.15)]"
+              className="flex-1 bg-primary hover:bg-primary-hover text-black font-bold uppercase py-2 min-h-[44px] flex items-center justify-center gap-1.5 shadow-[0_0_15px rgba(0,212,170,0.15)]"
               onClick={handleCreate}
               disabled={isCreating || isListing}
             >

--- a/apps/web/components/shared/AmountInput.tsx
+++ b/apps/web/components/shared/AmountInput.tsx
@@ -39,11 +39,10 @@ export function AmountInput({
       </label>
       <div className="relative">
         <input
-          type="number"
-          step="0.0000001"
-          min="0"
+          type="text"
+          inputMode="decimal"
           placeholder={placeholder}
-          className="w-full bg-[#080c10] border border-border rounded px-3 py-2 text-white text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all"
+          className="w-full bg-[#080c10] border border-border rounded px-3 py-2.5 text-white text-xs font-mono focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary transition-all min-h-[44px]"
           value={value}
           onChange={(e) => onChange(e.target.value)}
           disabled={disabled}


### PR DESCRIPTION
- Modal becomes full-screen sheet on mobile (<768px) and centered on md+
- All inputs have min-h-[44px] for touch-friendly tap targets
- Number inputs use inputMode='decimal'/'numeric' for correct mobile keyboard
- Due days input sanitizes non-digit chars
- Form scrolls within modal (overflow-y-auto + overscroll-contain) to keep keyboard from obscuring active field on iOS
- Step 1/Step 2 indicators visible and accessible on all screen sizes
- Checkbox, select, range slider sized for touch interaction
closes https://github.com/TrusTrove/TrusTrove-app/issues/7