### PR TITLE
feat: LP yield calculator on landing page right panel

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,25 @@
+## Summary
+
+Adds an interactive LP yield calculator to the landing page right panel, replacing the previous SME-focused "Finance Your Invoice" quick-action panel.
+
+## Changes
+
+- **New component** `apps/web/components/shared/LpYieldCalculator.tsx`
+  - "I'm an LP" tab header
+  - Deposit amount input via existing `AmountInput` component (USDC, default $10K)
+  - Pool utilization slider (default 75%, range 10-100%)
+  - Instant-updating outputs: estimated annual yield %, monthly earnings in USDC
+  - Plain CSS comparison bar chart: TrusTrove vs Savings Account (5%) vs T-Bills (4.5%)
+  - Disclaimer always visible: *"Yield depends on pool utilization and invoice repayment rate. Smart contract risk exists."*
+- **Updated** `apps/web/app/page.tsx` — right panel now renders `<LpYieldCalculator />`; unused imports removed
+
+## Acceptance Criteria
+
+- [x] All calculations update without page interaction
+- [x] Bar chart built with plain CSS bars — no chart library
+- [x] Disclaimer always visible
+- [x] Works on mobile viewport
+
+## Tech
+
+Next.js 14 · TypeScript · Tailwind CSS · React state

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,18 +1,15 @@
 'use client';
 
-import React, { useState } from 'react';
 import Link from 'next/link';
 import { TopStatusBar } from '@/components/shared/TopStatusBar';
 import { Navbar } from '@/components/shared/Navbar';
 import { InvoiceFeed } from '@/components/shared/InvoiceFeed';
+import { LpYieldCalculator } from '@/components/shared/LpYieldCalculator';
 import { DiscountCalculator } from '@/components/shared/DiscountCalculator';
-import { useWalletStore } from '@/store/wallet';
-import { useWallet } from '@/hooks/useWallet';
 import { 
   ShieldCheck, 
   FileCheck2, 
   Layers, 
-  ArrowRight, 
   Coins, 
   Database,
   ArrowRightLeft,
@@ -20,16 +17,6 @@ import {
 } from 'lucide-react';
 
 export default function Home() {
-  const { connected } = useWalletStore();
-  const { connectWallet } = useWallet();
-
-  // Quick Action Panel State
-  const [quickAmount, setQuickAmount] = useState('25000');
-  const [quickDays, setQuickDays] = useState('60');
-  
-  const parsedQuickAmt = parseFloat(quickAmount) || 0;
-  const quickDiscountFee = parsedQuickAmt * 0.02; // Fixed 2% for quick action
-  const quickPayout = parsedQuickAmt - quickDiscountFee;
 
   return (
     <div className="min-h-screen bg-background text-foreground flex flex-col selection:bg-primary selection:text-black">
@@ -107,76 +94,9 @@ export default function Home() {
             </div>
           </div>
 
-          {/* RIGHT: Quick-Action Calculator Panel */}
-          <div className="lg:col-span-4 bg-[#0d131a] border border-border rounded-lg p-5 space-y-4 shadow-[0_0_30px_rgba(0,212,170,0.02)]">
-            <h3 className="text-xs font-bold font-mono text-white uppercase tracking-wider border-b border-border/40 pb-2 flex items-center justify-between">
-              <span>FINANCE YOUR INVOICE</span>
-              <span className="text-primary text-[10px]">2% DISC</span>
-            </h3>
-
-            <div className="space-y-4">
-              <div className="space-y-1.5">
-                <label className="block text-[10px] font-bold font-mono text-slate-500 uppercase">
-                  Invoice Face Value (USDC)
-                </label>
-                <div className="relative">
-                  <input
-                    type="number"
-                    value={quickAmount}
-                    onChange={(e) => setQuickAmount(e.target.value)}
-                    className="w-full bg-[#080c10] border border-border rounded px-3 py-2 text-white font-mono text-xs focus:outline-none focus:border-primary"
-                    placeholder="25,000"
-                  />
-                  <span className="absolute right-3 top-2 text-[10px] font-mono text-slate-500">USDC</span>
-                </div>
-              </div>
-
-              <div className="space-y-1.5">
-                <label className="block text-[10px] font-bold font-mono text-slate-500 uppercase">
-                  Maturity Term
-                </label>
-                <select
-                  value={quickDays}
-                  onChange={(e) => setQuickDays(e.target.value)}
-                  className="w-full bg-[#080c10] border border-border rounded px-3 py-2 text-slate-300 font-mono text-xs focus:outline-none focus:border-primary"
-                >
-                  <option value="30">30 Days</option>
-                  <option value="60">60 Days</option>
-                  <option value="90">90 Days</option>
-                </select>
-              </div>
-
-              {/* Real-time preview */}
-              <div className="bg-[#080c10] border border-border/60 rounded p-3 text-xs font-mono space-y-2">
-                <div className="flex justify-between">
-                  <span className="text-slate-500">Financing Fee (2.0%):</span>
-                  <span className="text-rose-400">-{quickDiscountFee.toLocaleString()} USDC</span>
-                </div>
-                <div className="flex justify-between border-t border-border/25 pt-2 font-bold text-emerald-400">
-                  <span>Receive Today:</span>
-                  <span>{quickPayout.toLocaleString()} USDC</span>
-                </div>
-              </div>
-
-              {/* Call to Action */}
-              {connected ? (
-                <Link
-                  href="/dashboard"
-                  className="w-full bg-primary hover:bg-primary-hover text-black font-bold uppercase tracking-wider text-xs rounded py-2.5 flex items-center justify-center gap-1.5 shadow-[0_0_15px_rgba(0,212,170,0.15)] transition-all"
-                >
-                  <span>SUBMIT INVOICE DIRECTLY</span>
-                  <ArrowRight className="w-3.5 h-3.5" />
-                </Link>
-              ) : (
-                <button
-                  onClick={connectWallet}
-                  className="w-full bg-primary hover:bg-primary-hover text-black font-bold uppercase tracking-wider text-xs rounded py-2.5 flex items-center justify-center gap-1.5 shadow-[0_0_15px_rgba(0,212,170,0.15)] transition-all"
-                >
-                  <Coins className="w-3.5 h-3.5" />
-                  <span>CONNECT FREIGHTER TO START</span>
-                </button>
-              )}
-            </div>
+          {/* RIGHT: LP Yield Calculator */}
+          <div className="lg:col-span-4">
+            <LpYieldCalculator />
           </div>
         </div>
 

--- a/apps/web/components/shared/LpYieldCalculator.tsx
+++ b/apps/web/components/shared/LpYieldCalculator.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import React, { useState } from 'react';
+import { AmountInput } from './AmountInput';
+import { TrendingUp, PiggyBank, Landmark } from 'lucide-react';
+
+const SAVINGS_APY = 5.0;
+const TBILLS_APY = 4.5;
+const AVG_DISCOUNT_RATE = 2.0;
+const AVG_MATURITY_DAYS = 60;
+
+export function LpYieldCalculator() {
+  const [deposit, setDeposit] = useState('10000');
+  const [utilization, setUtilization] = useState(75);
+
+  const parsedDeposit = parseFloat(deposit) || 0;
+
+  const annualYieldPct =
+    (utilization / 100) *
+    (AVG_DISCOUNT_RATE / 100) *
+    (365 / AVG_MATURITY_DAYS) *
+    100;
+
+  const monthlyEarnings = parsedDeposit * (annualYieldPct / 100) / 12;
+
+  const maxApy = Math.max(annualYieldPct, SAVINGS_APY, TBILLS_APY);
+  const trustroveWidth = maxApy > 0 ? (annualYieldPct / maxApy) * 100 : 0;
+  const savingsWidth = (SAVINGS_APY / maxApy) * 100;
+  const tbillWidth = (TBILLS_APY / maxApy) * 100;
+
+  return (
+    <div className="bg-[#0d131a] border border-border rounded-lg p-5 space-y-5 shadow-[0_0_30px_rgba(0,212,170,0.02)]">
+      <h3 className="text-xs font-bold font-mono text-white uppercase tracking-wider border-b border-border/40 pb-2 flex items-center justify-between">
+        <span>I&apos;m an LP</span>
+        <span className="text-primary text-[10px]">YIELD CALC</span>
+      </h3>
+
+      <div className="space-y-4">
+        <AmountInput
+          value={deposit}
+          onChange={setDeposit}
+          asset="USDC"
+          label="Deposit Amount (USDC)"
+          placeholder="10,000"
+        />
+
+        <div className="space-y-2">
+          <div className="flex justify-between text-xs font-mono">
+            <span className="text-slate-400">Pool Utilization</span>
+            <span className="text-primary font-bold">{utilization}%</span>
+          </div>
+          <input
+            type="range"
+            min="10"
+            max="100"
+            step="1"
+            value={utilization}
+            onChange={(e) => setUtilization(parseInt(e.target.value))}
+            className="w-full accent-primary bg-slate-900 h-1.5 rounded"
+          />
+          <div className="flex justify-between text-[10px] text-slate-600 font-mono">
+            <span>10%</span>
+            <span>100%</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-[#080c10] border border-border/60 rounded p-4 space-y-3">
+        <div className="flex justify-between items-center">
+          <span className="text-[10px] font-mono text-slate-500 uppercase tracking-wider">
+            Estimated Annual Yield
+          </span>
+          <span className="text-2xl font-extrabold font-mono text-emerald-400">
+            {annualYieldPct.toFixed(2)}%
+          </span>
+        </div>
+        <div className="flex justify-between items-center border-t border-border/25 pt-2">
+          <span className="text-[10px] font-mono text-slate-500 uppercase tracking-wider">
+            Monthly Earnings
+          </span>
+          <span className="text-sm font-bold font-mono text-white">
+            {monthlyEarnings.toLocaleString('en-US', {
+              minimumFractionDigits: 2,
+              maximumFractionDigits: 2,
+            })} USDC
+          </span>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <span className="text-[10px] font-bold font-mono text-slate-500 uppercase tracking-wider block">
+          Yield Comparison
+        </span>
+
+        <div className="space-y-2.5">
+          <div>
+            <div className="flex justify-between text-[10px] font-mono mb-1">
+              <span className="flex items-center gap-1 text-emerald-400">
+                <TrendingUp className="w-3 h-3" />
+                TrusTrove LP
+              </span>
+              <span className="text-white font-bold">{annualYieldPct.toFixed(2)}%</span>
+            </div>
+            <div className="w-full h-3 bg-slate-800 rounded-sm overflow-hidden">
+              <div
+                className="h-full bg-gradient-to-r from-emerald-500 to-emerald-400 rounded-sm transition-all duration-300"
+                style={{ width: `${Math.min(trustroveWidth, 100)}%` }}
+              />
+            </div>
+          </div>
+
+          <div>
+            <div className="flex justify-between text-[10px] font-mono mb-1">
+              <span className="flex items-center gap-1 text-blue-400">
+                <PiggyBank className="w-3 h-3" />
+                Savings Account
+              </span>
+              <span className="text-white font-bold">{SAVINGS_APY.toFixed(2)}%</span>
+            </div>
+            <div className="w-full h-3 bg-slate-800 rounded-sm overflow-hidden">
+              <div
+                className="h-full bg-gradient-to-r from-blue-500 to-blue-400 rounded-sm transition-all duration-300"
+                style={{ width: `${savingsWidth}%` }}
+              />
+            </div>
+          </div>
+
+          <div>
+            <div className="flex justify-between text-[10px] font-mono mb-1">
+              <span className="flex items-center gap-1 text-amber-400">
+                <Landmark className="w-3 h-3" />
+                T-Bills
+              </span>
+              <span className="text-white font-bold">{TBILLS_APY.toFixed(2)}%</span>
+            </div>
+            <div className="w-full h-3 bg-slate-800 rounded-sm overflow-hidden">
+              <div
+                className="h-full bg-gradient-to-r from-amber-500 to-amber-400 rounded-sm transition-all duration-300"
+                style={{ width: `${tbillWidth}%` }}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="border-t border-border/40 pt-3">
+        <span className="text-[10px] font-mono text-slate-600 block leading-relaxed">
+          Yield depends on pool utilization and invoice repayment rate. Smart contract risk exists.
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #9 
## Summary

Adds an interactive LP yield calculator to the landing page right panel, replacing the previous SME-focused "Finance Your Invoice" quick-action panel.

## Changes

- **New component** `apps/web/components/shared/LpYieldCalculator.tsx`
  - "I'm an LP" tab header
  - Deposit amount input via existing `AmountInput` component (USDC, default $10K)
  - Pool utilization slider (default 75%, range 10-100%)
  - Instant-updating outputs: estimated annual yield %, monthly earnings in USDC
  - Plain CSS comparison bar chart: TrusTrove vs Savings Account (5%) vs T-Bills (4.5%)
  - Disclaimer always visible: *"Yield depends on pool utilization and invoice repayment rate. Smart contract risk exists."*
- **Updated** `apps/web/app/page.tsx` — right panel now renders `<LpYieldCalculator />`; unused imports removed

## Acceptance Criteria

- [x] All calculations update without page interaction
- [x] Bar chart built with plain CSS bars — no chart library
- [x] Disclaimer always visible
- [x] Works on mobile viewport

## Tech

Next.js 14 · TypeScript · Tailwind CSS · React state