### PR TITLE
fix(indexer): add total_shares to pool_snapshots schema and sync

### DIFF
--- a/indexer/db/migrations/001_initial.sql
+++ b/indexer/db/migrations/001_initial.sql
@@ -23,11 +23,12 @@ CREATE TABLE IF NOT EXISTS pool_snapshots (
     utilization_rate_bps INTEGER NOT NULL DEFAULT 0,
     total_yield_distributed NUMERIC NOT NULL DEFAULT 0,
     active_invoice_count INTEGER NOT NULL DEFAULT 0,
+    total_shares NUMERIC NOT NULL DEFAULT 0,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
-INSERT INTO pool_snapshots (id, total_deposits, total_funded, available_liquidity, utilization_rate_bps, total_yield_distributed, active_invoice_count)
-VALUES (1, 0, 0, 0, 0, 0, 0)
+INSERT INTO pool_snapshots (id, total_deposits, total_funded, available_liquidity, utilization_rate_bps, total_yield_distributed, active_invoice_count, total_shares)
+VALUES (1, 0, 0, 0, 0, 0, 0, 0)
 ON CONFLICT (id) DO NOTHING;
 
 CREATE TABLE IF NOT EXISTS events_log (

--- a/indexer/db/queries.go
+++ b/indexer/db/queries.go
@@ -34,6 +34,7 @@ type DbPoolStats struct {
 	UtilizationRateBps    int       `json:"utilization_rate_bps"`
 	TotalYieldDistributed string    `json:"total_yield_distributed"`
 	ActiveInvoiceCount    int       `json:"active_invoice_count"`
+	TotalShares           string    `json:"total_shares"`
 	UpdatedAt             time.Time `json:"updated_at"`
 }
 
@@ -243,7 +244,7 @@ func UpdateInvoiceStatus(ctx context.Context, id string, status string) error {
 
 func GetPoolStats(ctx context.Context) (*DbPoolStats, error) {
 	query := `
-		SELECT total_deposits, total_funded, available_liquidity, utilization_rate_bps, total_yield_distributed, active_invoice_count, updated_at
+		SELECT total_deposits, total_funded, available_liquidity, utilization_rate_bps, total_yield_distributed, active_invoice_count, total_shares, updated_at
 		FROM pool_snapshots
 		WHERE id = 1
 	`
@@ -252,7 +253,7 @@ func GetPoolStats(ctx context.Context) (*DbPoolStats, error) {
 	err := row.Scan(
 		&stats.TotalDeposits, &stats.TotalFunded, &stats.AvailableLiquidity,
 		&stats.UtilizationRateBps, &stats.TotalYieldDistributed, &stats.ActiveInvoiceCount,
-		&stats.UpdatedAt,
+		&stats.TotalShares, &stats.UpdatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -272,6 +273,7 @@ func UpdatePoolStats(ctx context.Context, stats *DbPoolStats) error {
 		    utilization_rate_bps = @utilization_rate_bps,
 		    total_yield_distributed = @total_yield_distributed,
 		    active_invoice_count = @active_invoice_count,
+		    total_shares = @total_shares,
 		    updated_at = CURRENT_TIMESTAMP
 		WHERE id = 1
 	`
@@ -282,6 +284,7 @@ func UpdatePoolStats(ctx context.Context, stats *DbPoolStats) error {
 		"utilization_rate_bps":      stats.UtilizationRateBps,
 		"total_yield_distributed":   stats.TotalYieldDistributed,
 		"active_invoice_count":      stats.ActiveInvoiceCount,
+		"total_shares":              stats.TotalShares,
 	}
 	_, err := Pool.Exec(ctx, query, args)
 	if err != nil {

--- a/indexer/listener/handlers.go
+++ b/indexer/listener/handlers.go
@@ -100,6 +100,7 @@ func SyncPoolStats(ctx context.Context, cfg *config.Config, serverKP *keypair.Fu
 	utilizationRateBps := 0
 	totalYieldDistributed := "0"
 	activeInvoiceCount := 0
+	totalShares := "0"
 
 	if val, ok := getMapValue(scValResult, "total_deposits"); ok {
 		totalDeposits = parseU128(val)
@@ -119,6 +120,9 @@ func SyncPoolStats(ctx context.Context, cfg *config.Config, serverKP *keypair.Fu
 	if val, ok := getMapValue(scValResult, "active_invoice_count"); ok {
 		activeInvoiceCount = parseU32(val)
 	}
+	if val, ok := getMapValue(scValResult, "total_shares"); ok {
+		totalShares = parseU128(val)
+	}
 
 	dbStats := &db.DbPoolStats{
 		TotalDeposits:         totalDeposits,
@@ -127,6 +131,7 @@ func SyncPoolStats(ctx context.Context, cfg *config.Config, serverKP *keypair.Fu
 		UtilizationRateBps:    utilizationRateBps,
 		TotalYieldDistributed: totalYieldDistributed,
 		ActiveInvoiceCount:    activeInvoiceCount,
+		TotalShares:           totalShares,
 	}
 
 	err = db.UpdatePoolStats(ctx, dbStats)


### PR DESCRIPTION
Add total_shares NUMERIC column to pool_snapshots migration, extend DbPoolStats and DB queries, and extract total_shares from on-chain get_stats in SyncPoolStats.

Closes #30