### PR TITLE
fix: align releaseToPool signature with contract spec (#23)

### DIFF
--- a/packages/sdk/src/clients/escrow.ts
+++ b/packages/sdk/src/clients/escrow.ts
@@ -24,12 +24,12 @@ export class EscrowClient extends BaseContractClient {
 
   async releaseToPool(
     invoiceIdHex: string,
-    withYield: boolean,
+    repaymentAmount: bigint,
     signerPublicKey: string
   ): Promise<boolean> {
     const args = [
       xdr.ScVal.scvBytes(Buffer.from(invoiceIdHex, 'hex')),
-      nativeToScVal(withYield, { type: 'bool' }),
+      nativeToScVal(repaymentAmount, { type: 'u128' }),
     ];
     return this.writeContract('release_to_pool', args, signerPublicKey).then(() => true);
   }


### PR DESCRIPTION
## Summary

Fixes a type mismatch in `EscrowClient.releaseToPool` where the method passed a `bool` XDR argument to a Soroban contract function expecting `u128`, causing transaction simulation/execution failures.

Closes #23

## Problem

The contract signature for `release_to_pool` is:

```rust
release_to_pool(env: Env, invoice_id: BytesN<32>, repayment_amount: u128) -> bool
```

But the SDK was sending:

```typescript
nativeToScVal(withYield, { type: bool })
```

This caused Soroban argument deserialization errors during transaction simulation.

## Fix

Changed `packages/sdk/src/clients/escrow.ts:25-32`:

- Parameter: `withYield: boolean` → `repaymentAmount: bigint`
- Serialization: `nativeToScVal(withYield, { type: bool })` → `nativeToScVal(repaymentAmount, { type: u128 })`

## Verification

- `pnpm build` (tsc) passes with zero errors
- No callers of `releaseToPool` exist in the codebase, so no additional updates needed