### PR TITLE
feat: enhance empty states with contextual guidance and CTA buttons

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -183,6 +183,20 @@ export default function SMEDashboard() {
                 invoices={invoices} 
                 onSelectInvoice={(invoice) => setSelectedInvoice(invoice)}
                 activeId={selectedInvoice?.id}
+                emptyState={
+                  <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
+                    <p className="text-slate-500 text-xs font-mono mb-6 leading-relaxed max-w-xs">
+                      Create your first invoice to get started
+                    </p>
+                    <button
+                      onClick={() => setShowCreateModal(true)}
+                      className="bg-primary hover:bg-primary-hover text-black font-bold uppercase tracking-wider text-xs rounded px-4 py-2.5 flex items-center gap-1.5 shadow-[0_0_15px_rgba(0,212,170,0.1)] transition-all"
+                    >
+                      <Plus className="w-4 h-4" />
+                      Create Invoice
+                    </button>
+                  </div>
+                }
               />
             )}
 

--- a/apps/web/app/marketplace/page.tsx
+++ b/apps/web/app/marketplace/page.tsx
@@ -165,6 +165,25 @@ export default function Marketplace() {
               invoices={filteredAndSortedInvoices} 
               onSelectInvoice={(invoice) => setSelectedInvoice(invoice)} 
               activeId={selectedInvoice?.id}
+              emptyState={
+                <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
+                  <p className="text-slate-500 text-xs font-mono mb-6 leading-relaxed max-w-xs">
+                    No invoices match your filters
+                  </p>
+                  <button
+                    onClick={() => {
+                      setStatusFilter('Listed');
+                      setMinAmount('');
+                      setMaxAmount('');
+                      setMaxDiscount('500');
+                      setSelectedInvoice(null);
+                    }}
+                    className="border border-border hover:border-primary/50 text-slate-300 hover:text-white font-bold text-xs uppercase tracking-wider rounded px-4 py-2.5 transition-all"
+                  >
+                    Reset Filters
+                  </button>
+                </div>
+              }
             />
 
             {/* Mobile Cards view (hidden on desktop, but let's implement layout) */}

--- a/apps/web/components/invoice/InvoiceTable.tsx
+++ b/apps/web/components/invoice/InvoiceTable.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Invoice } from '@/types';
 import { InvoiceStatus } from './InvoiceStatus';
 import { formatAmount } from '@/lib/assets';
@@ -9,14 +9,23 @@ interface InvoiceTableProps {
   invoices: Invoice[];
   onSelectInvoice?: (invoice: Invoice) => void;
   activeId?: string | null;
+  emptyState?: ReactNode;
 }
 
-export function InvoiceTable({ invoices, onSelectInvoice, activeId }: InvoiceTableProps) {
+export function InvoiceTable({ invoices, onSelectInvoice, activeId, emptyState }: InvoiceTableProps) {
 
   const truncateAddr = (addr: string) => {
     if (!addr) return '';
     return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
   };
+
+  if (invoices.length === 0 && emptyState) {
+    return (
+      <div className="bg-card border border-border rounded-lg overflow-hidden">
+        {emptyState}
+      </div>
+    );
+  }
 
   return (
     <div className="bg-card border border-border rounded-lg overflow-hidden">


### PR DESCRIPTION
## Summary

Replaces the generic `No invoices found.` empty state in `InvoiceTable` with contextual guidance and actionable buttons tailored to the page context.

## Changes

- **`apps/web/components/invoice/InvoiceTable.tsx`** — Added optional `emptyState` prop (`ReactNode`). When provided and invoices are empty, renders the custom content inside the card wrapper instead of the table. Falls back to the existing default row when no `emptyState` is given.
- **`apps/web/app/dashboard/page.tsx`** — Passes `emptyState` with message *`Create your first invoice to get started`* and a **Create Invoice** button that opens the existing creation modal.
- **`apps/web/app/marketplace/page.tsx`** — Passes `emptyState` with message *`No invoices match your filters`* and a **Reset Filters** button that clears all filter inputs and resets the status to `Listed`.

## Acceptance Criteria

- [x] Issuer dashboard empty state includes a helpful message and a CTA to create an invoice
- [x] Marketplace empty state includes a helpful message and a reset filters button
- [x] Backward compatible — callers that don't pass `emptyState` see the original behavior

Closes #103