### PR TITLE
feat: add skip button and sessionStorage caching to docs boot animation

### DIFF
--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -11,7 +11,17 @@ export default function DocsPage() {
   const [bootFinished, setBootFinished] = useState(false);
   const docUrl = 'https://k1ngd4vid.gitbook.io/trustrove/';
 
+  const redirect = () => {
+    sessionStorage.setItem('docs-boot-seen', 'true');
+    window.location.href = docUrl;
+  };
+
   useEffect(() => {
+    if (sessionStorage.getItem('docs-boot-seen')) {
+      window.location.href = docUrl;
+      return;
+    }
+
     const logMessages = [
       'INITIATING SECURE DOCS DISPATCH ROUTER...',
       'RESOLVING SYSTEM ROUTE: /docs',
@@ -42,6 +52,7 @@ export default function DocsPage() {
       setCountdown(prev => {
         if (prev <= 1) {
           clearInterval(countdownInterval);
+          sessionStorage.setItem('docs-boot-seen', 'true');
           window.location.href = docUrl;
           return 0;
         }
@@ -93,10 +104,20 @@ export default function DocsPage() {
               </div>
             ))}
             {!bootFinished && (
-              <div className="flex items-center gap-2 pt-1">
-                <Loader2 className="w-3 h-3 text-primary animate-spin" />
-                <span className="text-primary tracking-widest select-none">RESOLVING...</span>
-              </div>
+              <>
+                <div className="flex items-center gap-2 pt-1">
+                  <Loader2 className="w-3 h-3 text-primary animate-spin" />
+                  <span className="text-primary tracking-widest select-none">RESOLVING...</span>
+                </div>
+                <div className="pt-3">
+                  <button
+                    onClick={redirect}
+                    className="text-[10px] text-primary/70 hover:text-primary underline underline-offset-2 transition-colors uppercase tracking-wider"
+                  >
+                    [Skip to Docs]
+                  </button>
+                </div>
+              </>
             )}
             {bootFinished && (
               <div className="text-primary font-bold pt-2 select-none">
@@ -121,13 +142,13 @@ export default function DocsPage() {
               </div>
             </div>
 
-            <a
-              href={docUrl}
-              className="w-full sm:w-auto inline-flex items-center justify-center gap-1.5 px-4 py-2 bg-primary hover:bg-primary/90 text-[#0d131a] text-xs font-bold uppercase rounded transition-colors"
+            <button
+              onClick={redirect}
+              className="w-full sm:w-auto inline-flex items-center justify-center gap-1.5 px-4 py-2 bg-primary hover:bg-primary/90 text-[#0d131a] text-xs font-bold uppercase rounded transition-colors cursor-pointer"
             >
               <span>Access Docs</span>
               <ExternalLink className="w-3.5 h-3.5" />
-            </a>
+            </button>
           </div>
 
           {/* Footer Status */}


### PR DESCRIPTION
## Summary

Adds a `[Skip to Docs]` button visible immediately during the terminal boot sequence so users aren't forced to wait through the full animation and countdown before being redirected. Also uses `sessionStorage` so returning users skip the animation entirely within the same session.

## Changes

- **`apps/web/app/docs/page.tsx`** — Added `[Skip to Docs]` button inside the console boot output that is visible while the animation is playing. Clicking it calls the new `redirect()` helper which sets `sessionStorage` and navigates immediately.
- **Session caching** — On mount, checks `sessionStorage.getItem('docs-boot-seen')` and redirects immediately if set. The flag is also set by the countdown auto-redirect and the `Access Docs` button (converted from `<a>` to `<button>` so it can set the flag).

## Acceptance Criteria

- [x] Users can skip the animation and be redirected immediately via the `[Skip to Docs]` button
- [x] Returning users in the same session skip the animation entirely
- [x] All existing navigation paths (skip button, Access Docs button, countdown auto-redirect) set sessionStorage

Closes #102