### PR TITLE
feat: add persistent toast notifications for on-chain actions

### DIFF
--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Toaster } from 'sonner';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -19,6 +20,17 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       {children}
+      <Toaster
+        position="bottom-right"
+        toastOptions={{
+          style: {
+            background: '#0d131a',
+            border: '1px solid #1a2330',
+            color: '#e2e8f0',
+            fontFamily: 'ui-monospace, monospace',
+          },
+        }}
+      />
     </QueryClientProvider>
   );
 }

--- a/apps/web/hooks/useInvoices.ts
+++ b/apps/web/hooks/useInvoices.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getInvoices, getInvoiceByID, createInvoice } from '@/lib/api';
 import { InvoiceClient, PoolClient } from '@trusttrove/sdk';
 import { useWalletStore } from '@/store/wallet';
+import { showSuccessToast, showErrorToast } from '@/lib/toast';
 
 const invoiceContractID = process.env.NEXT_PUBLIC_INVOICE_CONTRACT_ID || '';
 const poolContractID = process.env.NEXT_PUBLIC_POOL_CONTRACT_ID || '';
@@ -56,6 +57,10 @@ export function useInvoices(filters?: { status?: string; issuer?: string }) {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['invoices'] });
+      showSuccessToast('Invoice Created');
+    },
+    onError: (error) => {
+      showErrorToast('Invoice Creation Failed', error instanceof Error ? error : undefined);
     },
   });
 
@@ -67,6 +72,10 @@ export function useInvoices(filters?: { status?: string; issuer?: string }) {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['invoices'] });
+      showSuccessToast('Invoice Listed for Financing');
+    },
+    onError: (error) => {
+      showErrorToast('Listing Failed', error instanceof Error ? error : undefined);
     },
   });
 
@@ -80,6 +89,10 @@ export function useInvoices(filters?: { status?: string; issuer?: string }) {
       queryClient.invalidateQueries({ queryKey: ['invoices'] });
       queryClient.invalidateQueries({ queryKey: ['poolStats'] });
       queryClient.invalidateQueries({ queryKey: ['lpPosition', address] });
+      showSuccessToast('Invoice Funded');
+    },
+    onError: (error) => {
+      showErrorToast('Funding Failed', error instanceof Error ? error : undefined);
     },
   });
 
@@ -91,6 +104,10 @@ export function useInvoices(filters?: { status?: string; issuer?: string }) {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['invoices'] });
+      showSuccessToast('Invoice Shipped');
+    },
+    onError: (error) => {
+      showErrorToast('Shipping Failed', error instanceof Error ? error : undefined);
     },
   });
 
@@ -102,6 +119,10 @@ export function useInvoices(filters?: { status?: string; issuer?: string }) {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['invoices'] });
+      showSuccessToast('Delivery Confirmed');
+    },
+    onError: (error) => {
+      showErrorToast('Confirmation Failed', error instanceof Error ? error : undefined);
     },
   });
 
@@ -115,6 +136,10 @@ export function useInvoices(filters?: { status?: string; issuer?: string }) {
       queryClient.invalidateQueries({ queryKey: ['invoices'] });
       queryClient.invalidateQueries({ queryKey: ['poolStats'] });
       queryClient.invalidateQueries({ queryKey: ['lpPosition', address] });
+      showSuccessToast('Invoice Repaid');
+    },
+    onError: (error) => {
+      showErrorToast('Repayment Failed', error instanceof Error ? error : undefined);
     },
   });
 
@@ -128,6 +153,10 @@ export function useInvoices(filters?: { status?: string; issuer?: string }) {
       queryClient.invalidateQueries({ queryKey: ['invoices'] });
       queryClient.invalidateQueries({ queryKey: ['poolStats'] });
       queryClient.invalidateQueries({ queryKey: ['lpPosition', address] });
+      showSuccessToast('Invoice Defaulted');
+    },
+    onError: (error) => {
+      showErrorToast('Default Action Failed', error instanceof Error ? error : undefined);
     },
   });
 

--- a/apps/web/hooks/usePool.ts
+++ b/apps/web/hooks/usePool.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getPoolStats, getLPPosition } from '@/lib/api';
 import { PoolClient } from '@trusttrove/sdk';
 import { useWalletStore } from '@/store/wallet';
+import { showSuccessToast, showErrorToast } from '@/lib/toast';
 
 const poolContractID = process.env.NEXT_PUBLIC_POOL_CONTRACT_ID || '';
 
@@ -60,9 +61,13 @@ export function usePool() {
       const poolClient = new PoolClient(poolContractID);
       return poolClient.deposit(address, amount, address);
     },
-    onSuccess: () => {
+    onSuccess: (txHash) => {
       queryClient.invalidateQueries({ queryKey: ['poolStats'] });
       queryClient.invalidateQueries({ queryKey: ['lpPosition', address] });
+      showSuccessToast('Deposit Complete', typeof txHash === 'string' ? txHash : undefined);
+    },
+    onError: (error) => {
+      showErrorToast('Deposit Failed', error instanceof Error ? error : undefined);
     },
   });
 
@@ -78,9 +83,13 @@ export function usePool() {
       const poolClient = new PoolClient(poolContractID);
       return poolClient.withdraw(address, shares, address);
     },
-    onSuccess: () => {
+    onSuccess: (txHash) => {
       queryClient.invalidateQueries({ queryKey: ['poolStats'] });
       queryClient.invalidateQueries({ queryKey: ['lpPosition', address] });
+      showSuccessToast('Withdrawal Complete', typeof txHash === 'string' ? txHash : undefined);
+    },
+    onError: (error) => {
+      showErrorToast('Withdrawal Failed', error instanceof Error ? error : undefined);
     },
   });
 

--- a/apps/web/lib/toast.tsx
+++ b/apps/web/lib/toast.tsx
@@ -1,0 +1,29 @@
+import { toast } from 'sonner';
+
+const explorerUrl = (txHash: string) =>
+  `https://stellar.expert/explorer/testnet/tx/${txHash}`;
+
+export function showSuccessToast(action: string, txHash?: string) {
+  toast.success(action, {
+    description: txHash ? (
+      <a
+        href={explorerUrl(txHash)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary underline underline-offset-2 hover:text-primary/80 text-xs font-mono"
+      >
+        View on Stellar Expert →
+      </a>
+    ) : undefined,
+    duration: 5000,
+  });
+}
+
+export function showErrorToast(action: string, error?: Error) {
+  toast.error(action, {
+    description: error?.message ? (
+      <span className="text-xs font-mono text-red-400/80">{error.message}</span>
+    ) : undefined,
+    duration: 6000,
+  });
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "next": "14.2.35",
     "react": "^18",
     "react-dom": "^18",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^4.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -296,6 +299,7 @@ packages:
   '@stellar/stellar-base@13.1.0':
     resolution: {integrity: sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==}
     engines: {node: '>=18.0.0'}
+    deprecated: This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.
 
   '@stellar/stellar-sdk@13.3.0':
     resolution: {integrity: sha512-8+GHcZLp+mdin8gSjcgfb/Lb6sSMYRX6Nf/0LcSJxvjLQR0XHpjGzOiRbYb2jSXo51EnA6kAV5j+4Pzh5OUKUg==}
@@ -1851,6 +1855,12 @@ packages:
   sodium-native@4.3.3:
     resolution: {integrity: sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==}
 
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2936,8 +2946,8 @@ snapshots:
       '@typescript-eslint/parser': 8.61.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -2956,7 +2966,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -2967,22 +2977,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.61.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -2993,7 +3003,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.61.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -3969,6 +3979,11 @@ snapshots:
     transitivePeerDependencies:
       - bare-url
     optional: true
+
+  sonner@2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary

Adds a toast notification system using `sonner` so users get non-blocking visual confirmation after every on-chain action, even after dismissing the transaction modal.

## Changes

- **`apps/web/lib/toast.tsx`** — New file with `showSuccessToast(action, txHash?)` and `showErrorToast(action, error?)` helpers. Success toasts include a *View on Stellar Expert →* explorer link when a transaction hash is available.
- **`apps/web/app/providers.tsx`** — Added `<Toaster>` component styled to match the app's dark theme.
- **`apps/web/hooks/useInvoices.ts`** — Added `onSuccess`/and `onError` toasts to all 7 mutations: create, list, fund, ship, confirm delivery, repay, default.
- **`apps/web/hooks/usePool.ts`** — Added `onSuccess`/and `onError` toasts to deposit and withdraw mutations. The txHash from `PoolClient.deposit()` / `PoolClient.withdraw()` is passed through for the explorer link.
- **`apps/web/package.json`** — Added `sonner` dependency.

## Acceptance Criteria

- [x] Every on-chain action shows a non-blocking toast notification on success
- [x] Error toasts are shown on mutation failure
- [x] Toasts include the action type and an explorer link when a txHash is available
- [x] `sonner` is installed and configured in the root layout

Closes #104