### PR TITLE
fix(sdk): change PoolClient.deposit return type from Promise<bigint> to Promise<string>

### DIFF
--- a/apps/web/hooks/usePool.ts
+++ b/apps/web/hooks/usePool.ts
@@ -64,7 +64,7 @@ export function usePool() {
     onSuccess: (txHash) => {
       queryClient.invalidateQueries({ queryKey: ['poolStats'] });
       queryClient.invalidateQueries({ queryKey: ['lpPosition', address] });
-      showSuccessToast('Deposit Complete', typeof txHash === 'string' ? txHash : undefined);
+      showSuccessToast('Deposit Complete', txHash);
     },
     onError: (error) => {
       showErrorToast('Deposit Failed', error instanceof Error ? error : undefined);

--- a/packages/sdk/src/clients/pool.ts
+++ b/packages/sdk/src/clients/pool.ts
@@ -8,21 +8,12 @@ export class PoolClient extends BaseContractClient {
     lp: string,
     usdcAmount: bigint,
     signerPublicKey: string
-  ): Promise<bigint> {
+  ): Promise<string> {
     const args = [
       new Address(lp).toScVal(),
       nativeToScVal(usdcAmount, { type: 'u128' }),
     ];
-    // deposit returns shares as u128
-    return this.writeContract('deposit', args, signerPublicKey).then(async (txHash) => {
-      // Return value can be parsed or we can return the receipt, but let's just return the transaction hash or simulated shares.
-      // Since it's a write call, it returns txHash string.
-      // Wait, the client method signature u128 is returned by the contract, but writeContract returns the txHash string on-chain.
-      // Let's modify the SDK method return to be Promise<string> since on-chain write calls return transaction hashes!
-      // This is a standard and robust pattern because clients need the txHash to track confirmation,
-      // and they can query get_lp_position afterwards to get updated shares.
-      return txHash as any;
-    });
+    return this.writeContract('deposit', args, signerPublicKey);
   }
 
   async withdraw(


### PR DESCRIPTION
## Description

Fixes #24

`PoolClient.deposit` was typed as `Promise<bigint>` but actually returned a transaction hash string from `writeContract`. This caused compile-time/runtime drift — callers expecting a `bigint` (shares count) received a tx hash string instead.

## Changes

### `packages/sdk/src/clients/pool.ts`
- Changed return type from `Promise<bigint>` to `Promise<string>`
- Removed unnecessary `.then()` wrapper and `txHash as any` cast
- Implementation now directly returns `this.writeContract('deposit', args, signerPublicKey)` — consistent with `withdraw()`

### `apps/web/hooks/usePool.ts`
- Removed `typeof txHash === 'string' ? txHash : undefined` guard in the deposit mutation's `onSuccess` handler, since `txHash` is now always a `string`

## Verification

- [x] Return type updated in SDK
- [x] Frontend usage adjusted
- [x] No other callers of `PoolClient.deposit` exist in the codebase