### PR TITLE
fix: replace wildcard CORS, add security headers and rate limiting (#69)

### DIFF
--- a/indexer/api/router.go
+++ b/indexer/api/router.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -56,14 +58,89 @@ func AuthMiddleware(jwtSecret string) func(http.Handler) http.Handler {
 	}
 }
 
-func CORSMiddleware() func(http.Handler) http.Handler {
+func CORSMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
+	originSet := make(map[string]struct{}, len(allowedOrigins))
+	for _, o := range allowedOrigins {
+		originSet[o] = struct{}{}
+	}
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Access-Control-Allow-Origin", "*")
+			origin := r.Header.Get("Origin")
+
+			if _, ok := originSet[origin]; ok {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+			} else if origin == "" {
+				w.Header().Set("Access-Control-Allow-Origin", "")
+			}
+
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+
 			if r.Method == "OPTIONS" {
-				w.WriteHeader(http.StatusOK)
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func SecurityHeadersMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Security-Policy", "default-src 'self'")
+			w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			w.Header().Set("X-Frame-Options", "DENY")
+			w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+type rateLimiter struct {
+	mu       sync.Mutex
+	tokens   float64
+	last     time.Time
+	rps      float64
+	burst    int
+}
+
+func newRateLimiter(rps int, burst int) *rateLimiter {
+	return &rateLimiter{
+		tokens: float64(burst),
+		last:   time.Now(),
+		rps:    float64(rps),
+		burst:  burst,
+	}
+}
+
+func (rl *rateLimiter) allow() bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	elapsed := now.Sub(rl.last).Seconds()
+	rl.tokens += elapsed * rl.rps
+	if rl.tokens > float64(rl.burst) {
+		rl.tokens = float64(rl.burst)
+	}
+	rl.last = now
+
+	if rl.tokens >= 1 {
+		rl.tokens--
+		return true
+	}
+	return false
+}
+
+func RateLimitMiddleware(rl *rateLimiter) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !rl.allow() {
+				w.Header().Set("Retry-After", "1")
+				http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
 				return
 			}
 			next.ServeHTTP(w, r)
@@ -74,11 +151,16 @@ func CORSMiddleware() func(http.Handler) http.Handler {
 func NewRouter(h *APIHandler) *chi.Mux {
 	r := chi.NewRouter()
 
+	// Global middleware
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
-	r.Use(CORSMiddleware())
+	r.Use(CORSMiddleware(h.cfg.CORSAllowedOrigins))
+	r.Use(SecurityHeadersMiddleware())
+
+	// Global rate limiter for auth and invoice creation
+	rl := newRateLimiter(h.cfg.RateLimitRPS, h.cfg.RateLimitRPS*2)
 
 	// Health check
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
@@ -87,9 +169,12 @@ func NewRouter(h *APIHandler) *chi.Mux {
 		w.Write([]byte(`{"status": "ok"}`))
 	})
 
-	// Unprotected authentication routes
-	r.Get("/auth", h.HandleGetAuth)
-	r.Post("/auth", h.HandlePostAuth)
+	// Unprotected authentication routes (rate limited)
+	r.Group(func(r chi.Router) {
+		r.Use(RateLimitMiddleware(rl))
+		r.Get("/auth", h.HandleGetAuth)
+		r.Post("/auth", h.HandlePostAuth)
+	})
 
 	// Public protocol stats (cached, no auth)
 	r.Get("/stats", h.HandleGetStats)
@@ -101,9 +186,10 @@ func NewRouter(h *APIHandler) *chi.Mux {
 	r.Get("/pool/stats", h.HandleGetPoolStats)
 	r.Get("/pool/position/{address}", h.HandleGetLPPosition)
 
-	// Protected routes
+	// Protected routes (rate limited)
 	r.Group(func(r chi.Router) {
 		r.Use(AuthMiddleware(h.cfg.JWTSecret))
+		r.Use(RateLimitMiddleware(rl))
 		r.Post("/invoices", h.HandleCreateInvoice)
 	})
 

--- a/indexer/config/config.go
+++ b/indexer/config/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	IndexerPollIntervalMs int
 	JWTSecret             string
 	JWTExpiryHours        int
+	CORSAllowedOrigins    []string
+	RateLimitRPS          int
 }
 
 func LoadConfig() (*Config, error) {
@@ -67,6 +69,27 @@ func LoadConfig() (*Config, error) {
 		apiPort = "8080"
 	}
 
+	originsStr := os.Getenv("CORS_ALLOWED_ORIGINS")
+	var corsOrigins []string
+	if originsStr != "" {
+		for _, origin := range strings.Split(originsStr, ",") {
+			origin = strings.TrimSpace(origin)
+			if origin != "" {
+				corsOrigins = append(corsOrigins, origin)
+			}
+		}
+	}
+	if len(corsOrigins) == 0 {
+		corsOrigins = []string{"http://localhost:3000"}
+	}
+
+	rateLimitRPS := 10
+	if rateLimitStr := os.Getenv("RATE_LIMIT_RPS"); rateLimitStr != "" {
+		if val, err := strconv.Atoi(rateLimitStr); err == nil && val > 0 {
+			rateLimitRPS = val
+		}
+	}
+
 	cfg := &Config{
 		StellarNetwork:        getRequired("STELLAR_NETWORK"),
 		HorizonURL:            getRequired("HORIZON_URL"),
@@ -83,6 +106,8 @@ func LoadConfig() (*Config, error) {
 		IndexerPollIntervalMs: pollIntervalMs,
 		JWTSecret:             getRequired("JWT_SECRET"),
 		JWTExpiryHours:        jwtExpiryHours,
+		CORSAllowedOrigins:    corsOrigins,
+		RateLimitRPS:          rateLimitRPS,
 	}
 
 	if len(missing) > 0 {


### PR DESCRIPTION
## Summary

Replaces the permissive `Access-Control-Allow-Origin: *` CORS configuration with a whitelist of allowed origins, adds security headers on all responses, and introduces rate limiting on auth and invoice creation endpoints.

## Changes

- **CORS** — `CORSMiddleware` now accepts `allowedOrigins []string` and validates the `Origin` header against the whitelist. Configured via `CORS_ALLOWED_ORIGINS` env var (comma-separated, defaults to `http://localhost:3000`).
- **Security Headers** — New `SecurityHeadersMiddleware` sets `Content-Security-Policy`, `Strict-Transport-Security`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and `Referrer-Policy` on every response.
- **Rate Limiting** — New token-bucket `RateLimitMiddleware` applied to `/auth` (GET + POST) and `POST /invoices`. Configured via `RATE_LIMIT_RPS` env var (defaults to 10).
- OPTIONS preflight now returns 204 No Content instead of 200 OK.

## Acceptance Criteria

- [x] CORS only allows configured origins
- [x] Security headers present on all responses
- [x] Rate limiting active on auth and invoice creation endpoints

Closes #69