### PR TITLE
fix(web): add aria-labels to icon-only buttons for accessibility (#72)

### DIFF
--- a/apps/web/app/invoice/[invoiceId]/InvoiceDetailClient.tsx
+++ b/apps/web/app/invoice/[invoiceId]/InvoiceDetailClient.tsx
@@ -182,6 +182,7 @@ export default function InvoiceDetailClient({ invoiceId }: InvoiceDetailClientPr
               <button
                 onClick={() => copyToClipboard(invoice.id, 'id')}
                 className="text-slate-600 hover:text-primary transition-colors"
+                aria-label="Copy invoice ID"
               >
                 {copiedId ? <Check className="w-3.5 h-3.5 text-emerald-400" /> : <Copy className="w-3.5 h-3.5" />}
               </button>

--- a/apps/web/components/invoice/InvoiceCard.tsx
+++ b/apps/web/components/invoice/InvoiceCard.tsx
@@ -128,6 +128,7 @@ export function InvoiceCard({ invoice, role, onSelect, isSelected }: InvoiceCard
                 copyToClipboard(invoice.id, 'id');
               }}
               className="text-slate-600 hover:text-primary transition-colors p-0.5"
+              aria-label="Copy invoice ID"
             >
               {copiedId ? <Check className="w-3 h-3 text-emerald-400" /> : <Copy className="w-3 h-3" />}
             </button>
@@ -163,6 +164,7 @@ export function InvoiceCard({ invoice, role, onSelect, isSelected }: InvoiceCard
                 copyToClipboard(invoice.buyer, 'buyer');
               }}
               className="text-slate-600 hover:text-primary transition-colors"
+              aria-label="Copy buyer address"
             >
               {copiedBuyer ? <Check className="w-3 h-3 text-emerald-400" /> : <Copy className="w-3 h-3" />}
             </button>
@@ -404,6 +406,7 @@ export function InvoiceCard({ invoice, role, onSelect, isSelected }: InvoiceCard
               <button
                 onClick={handleCancelConfirmation}
                 className="text-slate-500 hover:text-slate-300 transition-colors"
+                aria-label="Close confirmation dialog"
               >
                 <X className="w-4 h-4" />
               </button>

--- a/apps/web/components/shared/WalletConnect.tsx
+++ b/apps/web/components/shared/WalletConnect.tsx
@@ -91,6 +91,7 @@ export function WalletConnect() {
               onClick={handleCopy}
               className="p-1.5 text-slate-500 hover:text-teal-400 transition-colors"
               title="Copy Address"
+              aria-label="Copy wallet address"
             >
               {copied ? (
                 <Check className="h-3.5 w-3.5 text-emerald-400" />
@@ -105,6 +106,7 @@ export function WalletConnect() {
               className="p-1.5 text-slate-500 hover:text-rose-400 transition-colors"
               onClick={disconnectWallet}
               title="Disconnect Wallet"
+              aria-label="Disconnect wallet"
             >
               <LogOut className="h-3.5 w-3.5" />
             </button>


### PR DESCRIPTION
Resolves #72 

Problem
Several interactive icon-only buttons throughout the application lacked an aria-label or visible text alternative. Consequently, screen readers either skipped these buttons entirely or provided unhelpful announcements (like "button"), making key actions inaccessible to users relying on assistive technologies.

Solution
Added descriptive aria-label attributes to the affected icon-only buttons so that screen readers can clearly announce their purpose:

Added aria-label="Copy invoice ID" to the invoice ID copy buttons in both InvoiceCard.tsx and InvoiceDetailClient.tsx.
Added aria-label="Copy buyer address" to the buyer address copy button in InvoiceCard.tsx.
Added aria-label="Close confirmation dialog" to the close modal button in InvoiceCard.tsx.
Added aria-label="Copy wallet address" and aria-label="Disconnect wallet" to the respective buttons in WalletConnect.tsx.
Acceptance Criteria Met
 All icon-only buttons have descriptive aria-label attributes.
 Screen readers can now correctly announce each button's action.