### PR TITLE
Connect wallet and Delivery mutation issue fixed

### DIFF
--- a/apps/web/app/invoice/[invoiceId]/InvoiceDetailClient.tsx
+++ b/apps/web/app/invoice/[invoiceId]/InvoiceDetailClient.tsx
@@ -387,15 +387,15 @@ export default function InvoiceDetailClient({ invoiceId }: InvoiceDetailClientPr
                     </Button>
                   )}
 
-                  {(invoice.status === 'Confirmed' || invoice.status === 'Active') && role === 'buyer' && (
-                    <Button
-                      className="w-full bg-emerald-600 hover:bg-emerald-500 text-white font-bold uppercase text-xs tracking-wider py-2.5 rounded shadow-[0_0_15px_rgba(16,185,129,0.15)]"
-                      onClick={() => handleAction(() => repayInvoice({ invoiceId: invoice.id }), 'Submitting USDC repayment...', 'Failed to repay invoice')}
-                      disabled={submitting}
-                    >
-                      REPAY {formatAmount(invoice.faceValue)}
-                    </Button>
-                  )}
+{invoice.status === 'Confirmed' && role === 'buyer' && (
+                     <Button
+                       className="w-full bg-emerald-600 hover:bg-emerald-500 text-white font-bold uppercase text-xs tracking-wider py-2.5 rounded shadow-[0_0_15px_rgba(16,185,129,0.15)]"
+                       onClick={() => handleAction(() => repayInvoice({ invoiceId: invoice.id }), 'Submitting USDC repayment...', 'Failed to repay invoice')}
+                       disabled={submitting}
+                     >
+                       REPAY {formatAmount(invoice.faceValue)}
+                     </Button>
+                   )}
 
                   {invoice.status === 'Active' && isOverdue && (
                     <Button

--- a/apps/web/components/invoice/InvoiceCard.tsx
+++ b/apps/web/components/invoice/InvoiceCard.tsx
@@ -337,27 +337,27 @@ export function InvoiceCard({ invoice, role, onSelect, isSelected }: InvoiceCard
             </Button>
           )}
 
-          {(invoice.status === 'Confirmed' || invoice.status === 'Active') && role === 'buyer' && (
-            <Button
-              className={`w-full font-bold uppercase tracking-wider text-xs rounded py-2 flex items-center justify-center gap-1.5 transition-all ${
-                isVerified
-                  ? 'bg-emerald-600 hover:bg-emerald-500 text-white'
-                  : 'bg-neutral-800 text-slate-500 border border-neutral-700 cursor-not-allowed opacity-60'
-              }`}
-              onClick={() => {
-                if (!isVerified) return;
-                requestConfirmation({
-                  label: 'Repay Invoice',
-                  fn: () => repayInvoice({ invoiceId: invoice.id }),
-                  errorMsg: 'Failed to repay invoice',
-                });
-              }}
-              disabled={loading || !isVerified}
-            >
-              <Wallet className="w-3.5 h-3.5" />
-              {loading ? 'REPAYING...' : 'REPAY INVOICE'}
-            </Button>
-          )}
+{invoice.status === 'Confirmed' && role === 'buyer' && (
+             <Button
+               className={`w-full font-bold uppercase tracking-wider text-xs rounded py-2 flex items-center justify-center gap-1.5 transition-all ${
+                 isVerified
+                   ? 'bg-emerald-600 hover:bg-emerald-500 text-white'
+                   : 'bg-neutral-800 text-slate-500 border border-neutral-700 cursor-not-allowed opacity-60'
+               }`}
+               onClick={() => {
+                 if (!isVerified) return;
+                 requestConfirmation({
+                   label: 'Repay Invoice',
+                   fn: () => repayInvoice({ invoiceId: invoice.id }),
+                   errorMsg: 'Failed to repay invoice',
+                 });
+               }}
+               disabled={loading || !isVerified}
+             >
+               <Wallet className="w-3.5 h-3.5" />
+               {loading ? 'REPAYING...' : 'REPAY INVOICE'}
+             </Button>
+           )}
 
           {invoice.status === 'Active' && isOverdue && (
             <Button

--- a/apps/web/hooks/useInvoices.ts
+++ b/apps/web/hooks/useInvoices.ts
@@ -117,20 +117,21 @@ export function useInvoices(filters?: { status?: string; issuer?: string; page?:
     },
   });
 
-  const confirmDeliveryMutation = useMutation({
-    mutationFn: async ({ invoiceId }: { invoiceId: string }) => {
-      if (!address) throw new Error('Wallet not connected');
-      const invoiceClient = new InvoiceClient(invoiceContractID);
-      return invoiceClient.confirmDelivery(invoiceId, address, address);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['invoices'] });
-      showSuccessToast('Delivery Confirmed');
-    },
-    onError: (error) => {
-      showErrorToast('Confirmation Failed', error instanceof Error ? error : undefined);
-    },
-  });
+const confirmDeliveryMutation = useMutation({
+      mutationFn: async ({ invoiceId }: { invoiceId: string }) => {
+        if (!address) throw new Error('Wallet not connected');
+        const invoiceClient = new InvoiceClient(invoiceContractID);
+        const invoice = await getInvoiceByID(invoiceId);
+        return invoiceClient.confirmDelivery(invoiceId, invoice.buyer, address);
+      },
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ['invoices'] });
+        showSuccessToast('Delivery Confirmed');
+      },
+      onError: (error) => {
+        showErrorToast('Confirmation Failed', error instanceof Error ? error : undefined);
+      },
+    });
 
   const repayInvoiceMutation = useMutation({
     mutationFn: async ({ invoiceId }: { invoiceId: string }) => {


### PR DESCRIPTION
I fixed two critical issues in the TrusTrove invoice system:

First, I corrected the confirmDeliveryMutation in apps/web/hooks/useInvoices.ts. The mutation was incorrectly passing the connected wallet address as both confirmerAddress and signerPublicKey. I modified it to fetch the invoice by ID and use the actual buyer's address as confirmerAddress (ensuring only the buyer can confirm delivery), while keeping the wallet address as signerPublicKey for transaction signing.

Second, I fixed premature repay button visibility in two files:
1. In `apps/web/components/invoice/InvoiceCard.tsx`, I changed the repay button condition from showing when status was `Confirmed` OR `Active` to ONLY when status is `Confirmed`.
2. In `apps/web/app/invoice/[invoiceId]/InvoiceDetailClient.tsx`, I made the same change to restrict the repay button to `Confirmed` status only.

These changes ensure:
- Only the actual invoice buyer can confirm delivery (fixing on-chain authentication failures)
- Repay button only appears after buyer confirms delivery (preventing premature repayment attempts that could fail or risk funds)

# Related issues:

### CLOSES #65 
### CLOSES #66 