### PR TITLE
feat(indexer): poll getTransaction after sendTransaction in HandleCre…

### DIFF
--- a/indexer/api/handlers.go
+++ b/indexer/api/handlers.go
@@ -626,12 +626,51 @@ func (h *APIHandler) HandleCreateInvoice(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	type GetTransactionResult struct {
+		Hash   string `json:"hash"`
+		Status string `json:"status"`
+		Error  string `json:"error"`
+	}
+	const maxPollAttempts = 30
+	pollDelay := 1 * time.Second
+	var txResult GetTransactionResult
+	pollAttempts := 0
+
+	for {
+		err = CallSorobanRPC(h.cfg.SorobanRPCURL, "getTransaction", map[string]string{"hash": submitResp.Hash}, &txResult)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("failed to poll transaction: %s", err.Error()), http.StatusInternalServerError)
+			return
+		}
+
+		if txResult.Status == "SUCCESS" {
+			break
+		}
+
+		if txResult.Status == "FAILED" {
+			errMsg := "transaction failed on-chain"
+			if txResult.Error != "" {
+				errMsg = fmt.Sprintf("transaction failed on-chain: %s", txResult.Error)
+			}
+			http.Error(w, errMsg, http.StatusInternalServerError)
+			return
+		}
+
+		pollAttempts++
+		if pollAttempts >= maxPollAttempts {
+			http.Error(w, fmt.Sprintf("transaction confirmation timed out after %d attempts: %s", maxPollAttempts, submitResp.Hash), http.StatusGatewayTimeout)
+			return
+		}
+
+		time.Sleep(pollDelay)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusAccepted)
+	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(map[string]string{
 		"invoice_id":       invoiceID,
 		"transaction_hash": submitResp.Hash,
-		"status":           submitResp.Status,
+		"status":           txResult.Status,
 	})
 }
 


### PR DESCRIPTION
Close #63 


PR Description
## Problem

The `HandleCreateInvoice` endpoint submits the transaction via
`sendTransaction` but returns immediately with status `PENDING` without
polling for on-chain confirmation. The server never knows if the
transaction actually succeeded or failed.

## Solution

After `sendTransaction` returns, poll `getTransaction` in a loop (up to
30 attempts at 1s intervals, matching the SDK pattern in
`packages/sdk/src/base.ts:161-180`). Only return the response after the
transaction status is confirmed.



