### PR TITLE
fix(InvoiceForm): use placeholder ID for simulation (#81)

### DIFF
--- a/apps/web/components/invoice/InvoiceForm.tsx
+++ b/apps/web/components/invoice/InvoiceForm.tsx
@@ -14,6 +14,10 @@ import { SimulationPreview } from '@/components/shared/SimulationPreview';
 
 const invoiceContractID = process.env.NEXT_PUBLIC_INVOICE_CONTRACT_ID || '';
 
+/** Zero-byte placeholder invoice ID for fee estimation simulation only */
+const SIMULATION_PLACEHOLDER_INVOICE_ID =
+  '0000000000000000000000000000000000000000000000000000000000000000';
+
 
 interface InvoiceFormProps {
   onSuccess?: () => void;
@@ -58,24 +62,8 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
 
       try {
         const invoiceClient = new InvoiceClient(invoiceContractID);
-        let invoiceIdToSimulate = '';
-
-        try {
-          const { getInvoices } = await import('@/lib/api');
-          const myInvoices = await getInvoices({ issuer: address });
-          if (myInvoices && myInvoices.data.length > 0) {
-            invoiceIdToSimulate = myInvoices.data[0].id;
-          }
-        } catch (e) {
-          console.warn('Failed to fetch existing invoices for simulation:', e);
-        }
-
-        if (!invoiceIdToSimulate) {
-          invoiceIdToSimulate = '0000000000000000000000000000000000000000000000000000000000000000';
-        }
-
         const args = [
-          xdr.ScVal.scvBytes(Buffer.from(invoiceIdToSimulate, 'hex')),
+          xdr.ScVal.scvBytes(Buffer.from(SIMULATION_PLACEHOLDER_INVOICE_ID, 'hex')),
           nativeToScVal(simulationDiscountBps, { type: 'u32' }),
         ];
 


### PR DESCRIPTION
Problem

When simulating a list_for_financing transaction, the InvoiceForm component dynamically imports getInvoices from @/lib/api and fetches all of the user's invoices from the indexer — just to grab the first invoice ID as a placeholder for fee estimation. This is wasteful because:

The simulation only needs a structurally valid 32-byte invoice ID — it doesn't matter which one.
The API call adds unnecessary latency before the simulation can even begin.
If the user has no invoices, it falls back to a zero-byte string anyway.
Solution

Replaced the dynamic fetch with a constant SIMULATION_PLACEHOLDER_INVOICE_ID (64-char hex zero string). The simulation only cares about the transaction structure for fee estimation, not the actual invoice data, so a zero-byte ID works identically.

typescript
const SIMULATION_PLACEHOLDER_INVOICE_ID =
  '0000000000000000000000000000000000000000000000000000000000000000';
This removes 16 lines of fetch logic, eliminates an API round-trip, and removes the dynamic import().

Impact

Eliminates 1 API call per simulation run
Removes dynamic import('@/lib/api') — simpler code path
Net -12 lines of code
Testing

Verified type checks pass (tsc --noEmit)
Verified production build succeeds (pnpm build)
Closes #81