### PR TITLE
fix(InvoiceForm): debounce simulation execution by 300ms (#80)

### DIFF
--- a/apps/web/components/invoice/InvoiceForm.tsx
+++ b/apps/web/components/invoice/InvoiceForm.tsx
@@ -99,9 +99,13 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
       }
     };
 
-    runSim();
+    const timerId = setTimeout(() => {
+      runSim();
+    }, 300);
+
     return () => {
       active = false;
+      clearTimeout(timerId);
     };
   }, [step, address, discountBps]);
 


### PR DESCRIPTION
Problem

The InvoiceForm component fires a Stellar contract simulation (simulateTransaction) inside a useEffect that depends on discountBps. Because the discount rate is bound to a range slider, dragging it fires the effect on every tick — potentially dozens of times per second — flooding the network with redundant RPC calls.

Solution

Wrapped the runSim() call in a 300ms setTimeout, with clearTimeout in the effect cleanup. This ensures simulation only fires once the user stops dragging the slider, eliminating the burst of redundant calls while keeping the UX responsive.

diff
-    runSim();
+    const timerId = setTimeout(() => {
+      runSim();
+    }, 300);
+
     return () => {
       active = false;
+      clearTimeout(timerId);
     };
Impact

Reduces Stellar RPC calls from ~50+/drag to 1 per slider interaction
Zero UX regression — simulation still updates promptly after the user releases the slider
No new dependencies
Testing

Verified type checks pass (tsc --noEmit)
Verified production build succeeds (pnpm build)
Closes #80