### PR TITLE
fix(web): debounce InvoiceForm simulation on step 2

### DIFF
--- a/apps/web/components/invoice/InvoiceForm.tsx
+++ b/apps/web/components/invoice/InvoiceForm.tsx
@@ -37,6 +37,14 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
   const [simError, setSimError] = useState<string | null>(null);
   const [isSimulating, setIsSimulating] = useState(false);
   const [isFallback, setIsFallback] = useState(false);
+  const [simulationDiscountBps, setSimulationDiscountBps] = useState(discountBps);
+
+  // Debounce discount changes so simulation only runs after slider settles on step 2
+  useEffect(() => {
+    if (step !== 2) return;
+    const timer = setTimeout(() => setSimulationDiscountBps(discountBps), 500);
+    return () => clearTimeout(timer);
+  }, [step, discountBps]);
 
   useEffect(() => {
     if (step !== 2 || !address) return;
@@ -68,7 +76,7 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
 
         const args = [
           xdr.ScVal.scvBytes(Buffer.from(invoiceIdToSimulate, 'hex')),
-          nativeToScVal(discountBps, { type: 'u32' }),
+          nativeToScVal(simulationDiscountBps, { type: 'u32' }),
         ];
 
         const simResult = await invoiceClient.simulateTransaction('list_for_financing', args, address);
@@ -103,7 +111,7 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
     return () => {
       active = false;
     };
-  }, [step, address, discountBps]);
+  }, [step, address, simulationDiscountBps]);
 
   const parsedValue = parseFloat(faceValue.replace(/,/g, '')) || 0;
   


### PR DESCRIPTION
Debounce discount rate changes by 500ms and only trigger simulation when entering the review step, preventing RPC calls during slider drag.

Fixes #80