### PR TITLE
fix(web): replace mock data with live indexer data + harden validation/redirects

### DIFF
--- a/apps/web/app/docs/page.tsx
+++ b/apps/web/app/docs/page.tsx
@@ -1,27 +1,23 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { Navbar } from '@/components/shared/Navbar';
 import { TopStatusBar } from '@/components/shared/TopStatusBar';
 import { BookOpen, Terminal, ExternalLink, Loader2 } from 'lucide-react';
 
 export default function DocsPage() {
+  const router = useRouter();
   const [logs, setLogs] = useState<string[]>([]);
-  const [countdown, setCountdown] = useState(3);
   const [bootFinished, setBootFinished] = useState(false);
   const docUrl = 'https://k1ngd4vid.gitbook.io/trustrove/';
 
-  const redirect = () => {
-    sessionStorage.setItem('docs-boot-seen', 'true');
-    window.location.href = docUrl;
+  // Navigate only on explicit user action — no forced/auto redirects.
+  const goToDocs = () => {
+    router.push(docUrl);
   };
 
   useEffect(() => {
-    if (sessionStorage.getItem('docs-boot-seen')) {
-      window.location.href = docUrl;
-      return;
-    }
-
     const logMessages = [
       'INITIATING SECURE DOCS DISPATCH ROUTER...',
       'RESOLVING SYSTEM ROUTE: /docs',
@@ -44,24 +40,6 @@ export default function DocsPage() {
 
     return () => clearInterval(logInterval);
   }, []);
-
-  useEffect(() => {
-    if (!bootFinished) return;
-
-    const countdownInterval = setInterval(() => {
-      setCountdown(prev => {
-        if (prev <= 1) {
-          clearInterval(countdownInterval);
-          sessionStorage.setItem('docs-boot-seen', 'true');
-          window.location.href = docUrl;
-          return 0;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-
-    return () => clearInterval(countdownInterval);
-  }, [bootFinished]);
 
   return (
     <div className="min-h-screen bg-background text-foreground flex flex-col selection:bg-primary selection:text-black">
@@ -111,7 +89,7 @@ export default function DocsPage() {
                 </div>
                 <div className="pt-3">
                   <button
-                    onClick={redirect}
+                    onClick={goToDocs}
                     className="text-[10px] text-primary/70 hover:text-primary underline underline-offset-2 transition-colors uppercase tracking-wider"
                   >
                     [Skip to Docs]
@@ -121,7 +99,7 @@ export default function DocsPage() {
             )}
             {bootFinished && (
               <div className="text-primary font-bold pt-2 select-none">
-                ✓ HANDSHAKE RESOLVED. REDIRECTING IN {countdown}...
+                ✓ HANDSHAKE RESOLVED. READY WHEN YOU ARE.
               </div>
             )}
           </div>
@@ -143,7 +121,7 @@ export default function DocsPage() {
             </div>
 
             <button
-              onClick={redirect}
+              onClick={goToDocs}
               className="w-full sm:w-auto inline-flex items-center justify-center gap-1.5 px-4 py-2 bg-primary hover:bg-primary/90 text-[#0d131a] text-xs font-bold uppercase rounded transition-colors cursor-pointer"
             >
               <span>Access Docs</span>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -6,7 +6,9 @@ import { Navbar } from '@/components/shared/Navbar';
 import { InvoiceFeed } from '@/components/shared/InvoiceFeed';
 import { LpYieldCalculator } from '@/components/shared/LpYieldCalculator';
 import { DiscountCalculator } from '@/components/shared/DiscountCalculator';
-import { 
+import { SkeletonShimmer } from '@/components/shared/SkeletonLoader';
+import { usePool } from '@/hooks/usePool';
+import {
   ShieldCheck, 
   FileCheck2, 
   Layers, 
@@ -17,6 +19,28 @@ import {
 } from 'lucide-react';
 
 export default function Home() {
+  const { stats, isStatsLoading, statsError } = usePool();
+
+  // Compact USDC formatting (e.g. "12.4M") derived from the stroop-denominated stat.
+  const formatCompactUsdc = (amount: bigint | undefined): string | null => {
+    if (amount === undefined) return null;
+    const value = Number(amount) / 10_000_000;
+    return value.toLocaleString('en-US', {
+      notation: 'compact',
+      maximumFractionDigits: 1,
+    });
+  };
+
+  // Per-stat renderer: skeleton while loading, graceful fallback when the indexer is unavailable.
+  const renderStat = (value: string | null) => {
+    if (isStatsLoading) {
+      return <SkeletonShimmer className="h-7 w-20 mx-auto lg:mx-0" />;
+    }
+    if (statsError || value === null) {
+      return <span className="text-xl sm:text-2xl font-bold font-mono text-slate-600 block">—</span>;
+    }
+    return <span className="text-xl sm:text-2xl font-bold font-mono text-white block">{value}</span>;
+  };
 
   return (
     <div className="min-h-screen bg-background text-foreground flex flex-col selection:bg-primary selection:text-black">
@@ -64,25 +88,19 @@ export default function Home() {
             {/* Core Stats Row */}
             <div className="grid grid-cols-3 gap-4 border-t border-b border-border/40 py-6">
               <div className="text-center lg:text-left">
-                <span className="text-xl sm:text-2xl font-bold font-mono text-white block">
-                  12.4M
-                </span>
+                {renderStat(formatCompactUsdc(stats?.totalDeposits))}
                 <span className="text-[10px] font-mono text-slate-500 uppercase font-bold tracking-wider block mt-1">
                   USDC POOL VALUE
                 </span>
               </div>
               <div className="text-center lg:text-left">
-                <span className="text-xl sm:text-2xl font-bold font-mono text-white block">
-                  4,821
-                </span>
+                {renderStat(stats ? stats.activeInvoiceCount.toLocaleString('en-US') : null)}
                 <span className="text-[10px] font-mono text-slate-500 uppercase font-bold tracking-wider block mt-1">
                   INVOICES FUNDED
                 </span>
               </div>
               <div className="text-center lg:text-left">
-                <span className="text-xl sm:text-2xl font-bold font-mono text-white block">
-                  245.8K
-                </span>
+                {renderStat(formatCompactUsdc(stats?.totalYieldDistributed))}
                 <span className="text-[10px] font-mono text-slate-500 uppercase font-bold tracking-wider block mt-1">
                   YIELD DISTRIBUTED
                 </span>

--- a/apps/web/components/invoice/InvoiceForm.tsx
+++ b/apps/web/components/invoice/InvoiceForm.tsx
@@ -9,7 +9,7 @@ import { ASSET_OPTIONS } from '@/lib/assets';
 import { AmountInput } from '@/components/shared/AmountInput';
 import { useWalletStore } from '@/store/wallet';
 import { InvoiceClient } from '@trusttrove/sdk';
-import { xdr, nativeToScVal } from '@stellar/stellar-sdk';
+import { xdr, nativeToScVal, StrKey } from '@stellar/stellar-sdk';
 import { SimulationPreview } from '@/components/shared/SimulationPreview';
 
 const invoiceContractID = process.env.NEXT_PUBLIC_INVOICE_CONTRACT_ID || '';
@@ -127,10 +127,12 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
     e.preventDefault();
     setError(null);
 
-    if (!buyer || buyer.length !== 56 || !buyer.startsWith('G')) {
-      setError('Buyer must be a valid Stellar public key (56 characters, starting with G)');
+    const trimmedBuyer = buyer.trim();
+    if (!trimmedBuyer || !StrKey.isValidEd25519PublicKey(trimmedBuyer)) {
+      setError('Buyer must be a valid Stellar public key (G... account address)');
       return;
     }
+    if (trimmedBuyer !== buyer) setBuyer(trimmedBuyer);
 
     if (parsedValue <= 0) {
       setError('Face value must be a positive number');

--- a/apps/web/components/shared/InvoiceFeed.tsx
+++ b/apps/web/components/shared/InvoiceFeed.tsx
@@ -1,46 +1,93 @@
 'use client';
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ArrowDownLeft, Zap } from 'lucide-react';
+import {
+  FilePlus2,
+  Tag,
+  Coins,
+  Truck,
+  PackageCheck,
+  BadgeCheck,
+  AlertTriangle,
+  Activity,
+  Zap,
+} from 'lucide-react';
+import { useRecentEvents } from '@/hooks/useEvents';
+import { InvoiceFeedSkeleton } from '@/components/shared/SkeletonLoader';
+import type { EventLog } from '@/types';
 
-interface FeedItem {
-  id: string;
-  type: string;
-  amount: string;
+const FEED_LIMIT = 6;
+const POLL_INTERVAL_MS = 10000;
+
+interface FeedEntry {
+  id: number;
+  label: string;
+  details: string;
   time: string;
-  discount: string;
-  flag: string;
+  Icon: typeof Activity;
 }
 
-const mockFeedItems: FeedItem[] = [
-  { id: '1', type: 'Lagos Textile Supplier', amount: '$34,500 USDC', time: 'Funded 3 min ago', discount: '2.1%', flag: '🇳🇬' },
-  { id: '2', type: 'Nairobi Agri-Exporter', amount: '$18,200 USDC', time: 'Funded 8 min ago', discount: '1.8%', flag: '🇰🇪' },
-  { id: '3', type: 'Accra Electronics', amount: '$52,000 USDC', time: 'Funded 12 min ago', discount: '2.5%', flag: '🇬🇭' },
-  { id: '4', type: 'Mombasa Logistics', amount: '$27,800 USDC', time: 'Funded 22 min ago', discount: '2.0%', flag: '🇰🇪' },
-  { id: '5', type: 'Dakar Fish Processing', amount: '$41,300 USDC', time: 'Funded 35 min ago', discount: '2.3%', flag: '🇸🇳' },
-  { id: '6', type: 'Kampala Agri-Hub', amount: '$15,400 USDC', time: 'Funded 42 min ago', discount: '1.9%', flag: '🇺🇬' },
-  { id: '7', type: 'Kumasi Cocoa Exporter', amount: '$63,000 USDC', time: 'Funded 58 min ago', discount: '2.4%', flag: '🇬🇭' },
-];
+const EVENT_LABELS: Record<string, string> = {
+  InvoiceCreated: 'Invoice Created',
+  create: 'Invoice Created',
+  InvoiceListed: 'Invoice Listed',
+  list_for_financing: 'Invoice Listed',
+  InvoiceFunded: 'Invoice Funded',
+  fund_invoice: 'Invoice Funded',
+  InvoiceShipped: 'Invoice Shipped',
+  mark_shipped: 'Invoice Shipped',
+  DeliveryConfirmed: 'Delivery Confirmed',
+  confirm_delivery: 'Delivery Confirmed',
+  InvoiceRepaid: 'Invoice Repaid',
+  repay: 'Invoice Repaid',
+  InvoiceDefaulted: 'Invoice Defaulted',
+  trigger_default: 'Invoice Defaulted',
+};
+
+const EVENT_ICONS: Record<string, typeof Activity> = {
+  InvoiceCreated: FilePlus2,
+  create: FilePlus2,
+  InvoiceListed: Tag,
+  list_for_financing: Tag,
+  InvoiceFunded: Coins,
+  fund_invoice: Coins,
+  InvoiceShipped: Truck,
+  mark_shipped: Truck,
+  DeliveryConfirmed: PackageCheck,
+  confirm_delivery: PackageCheck,
+  InvoiceRepaid: BadgeCheck,
+  repay: BadgeCheck,
+  InvoiceDefaulted: AlertTriangle,
+  trigger_default: AlertTriangle,
+};
+
+function formatRelativeTime(ledgerClosedAt: number): string {
+  const diff = Math.floor(Date.now() / 1000) - ledgerClosedAt;
+  if (diff < 60) return 'just now';
+  if (diff < 3600) return `${Math.floor(diff / 60)} min ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+function toFeedEntry(event: EventLog): FeedEntry {
+  const invoiceId = typeof event.data?.invoice_id === 'string' ? event.data.invoice_id : '';
+  const invoiceShort = invoiceId ? `INV#${invoiceId.slice(0, 6)}…` : 'On-chain event';
+  return {
+    id: event.id,
+    label: EVENT_LABELS[event.event_type] || event.event_type,
+    details: invoiceShort,
+    time: formatRelativeTime(event.ledger_closed_at),
+    Icon: EVENT_ICONS[event.event_type] || Activity,
+  };
+}
 
 export function InvoiceFeed() {
-  const [items, setItems] = useState<FeedItem[]>(mockFeedItems.slice(0, 4));
-  const indexRef = useRef(4);
+  const { events, isLoading } = useRecentEvents(FEED_LIMIT, {
+    refetchInterval: POLL_INTERVAL_MS,
+  });
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      const nextItem = mockFeedItems[indexRef.current % mockFeedItems.length];
-
-      setItems((prev) => [
-        { ...nextItem, id: String(Date.now()) },
-        ...prev.slice(0, 3),
-      ]);
-
-      indexRef.current += 1;
-    }, 3000);
-
-    return () => clearInterval(interval);
-  }, []);
+  const items = useMemo(() => events.slice(0, FEED_LIMIT).map(toFeedEntry), [events]);
 
   return (
     <div className="border border-border/80 bg-[#0d131a] rounded-lg overflow-hidden h-[340px] flex flex-col">
@@ -53,33 +100,49 @@ export function InvoiceFeed() {
       </div>
 
       <div className="flex-1 p-4 relative overflow-hidden flex flex-col gap-3 justify-start">
-        <AnimatePresence initial={false}>
-          {items.map((item) => (
-            <motion.div
-              key={item.id}
-              initial={{ opacity: 0, y: -40, scale: 0.95 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: 40, scale: 0.95, position: 'absolute', bottom: 16, left: 16, right: 16 }}
-              transition={{ type: 'spring', stiffness: 350, damping: 25 }}
-              className="bg-[#080c10] border border-border/40 p-3 rounded flex items-center justify-between gap-4 w-full"
-            >
-              <div className="flex items-center gap-2">
-                <div className="text-lg shrink-0 select-none">{item.flag}</div>
-                <div className="min-w-0">
-                  <span className="text-xs font-mono font-bold text-slate-300 block truncate">{item.type}</span>
-                  <span className="text-[9px] font-mono text-slate-500 block">{item.time}</span>
-                </div>
-              </div>
-              
-              <div className="text-right shrink-0">
-                <span className="text-xs font-mono font-bold text-primary block">{item.amount}</span>
-                <span className="text-[9px] font-mono text-sky-400 font-semibold block flex items-center justify-end gap-0.5">
-                  <ArrowDownLeft className="w-2.5 h-2.5" /> {item.discount} disc.
-                </span>
-              </div>
-            </motion.div>
-          ))}
-        </AnimatePresence>
+        {isLoading ? (
+          <InvoiceFeedSkeleton />
+        ) : items.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full text-center gap-2">
+            <Activity className="w-5 h-5 text-slate-600" />
+            <span className="text-[10px] font-mono text-slate-500 uppercase tracking-wider">
+              Awaiting on-chain activity
+            </span>
+          </div>
+        ) : (
+          <AnimatePresence initial={false}>
+            {items.map((item) => {
+              const { Icon } = item;
+              return (
+                <motion.div
+                  key={item.id}
+                  layout
+                  initial={{ opacity: 0, y: -40, scale: 0.95 }}
+                  animate={{ opacity: 1, y: 0, scale: 1 }}
+                  exit={{ opacity: 0, y: 40, scale: 0.95, position: 'absolute', bottom: 16, left: 16, right: 16 }}
+                  transition={{ type: 'spring', stiffness: 350, damping: 25 }}
+                  className="bg-[#080c10] border border-border/40 p-3 rounded flex items-center justify-between gap-4 w-full"
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <div className="text-primary shrink-0">
+                      <Icon className="w-4 h-4" />
+                    </div>
+                    <div className="min-w-0">
+                      <span className="text-xs font-mono font-bold text-slate-300 block truncate">{item.label}</span>
+                      <span className="text-[9px] font-mono text-slate-500 block">{item.time}</span>
+                    </div>
+                  </div>
+
+                  <div className="text-right shrink-0">
+                    <span className="text-[11px] font-mono font-bold text-primary block truncate max-w-[110px]">
+                      {item.details}
+                    </span>
+                  </div>
+                </motion.div>
+              );
+            })}
+          </AnimatePresence>
+        )}
       </div>
     </div>
   );

--- a/apps/web/hooks/useEvents.ts
+++ b/apps/web/hooks/useEvents.ts
@@ -1,10 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 import { getRecentEvents } from '@/lib/api';
 
-export function useRecentEvents(limit?: number) {
+interface UseRecentEventsOptions {
+  /** Polling interval in milliseconds. When set, the query refetches on this cadence. */
+  refetchInterval?: number;
+}
+
+export function useRecentEvents(limit?: number, options?: UseRecentEventsOptions) {
   const eventsQuery = useQuery({
     queryKey: ['recentEvents', limit],
     queryFn: () => getRecentEvents(limit),
+    refetchInterval: options?.refetchInterval,
   });
 
   return {


### PR DESCRIPTION
## Summary

Replaces hardcoded/mock UI data with live indexer queries and hardens two interaction points. Each fix is an atomic commit.

### #128 — InvoiceFeed displays static mock data instead of live event stream
- Removed the hardcoded `mockFeedItems` array and the 3s cycling timer.
- `InvoiceFeed` now queries `useRecentEvents()` and maps `EventLog[]` (event type, invoice id, relative time) into the feed.
- Polls every 10s so new on-chain activity appears at the top within one cycle.
- Added a loading skeleton (`InvoiceFeedSkeleton`) and an empty state.
- `useRecentEvents` gained an optional `refetchInterval` option.

### #129 — Home page pool statistics are hardcoded placeholder values
- Replaced the `12.4M` / `4,821` / `245.8K` hero metrics with `usePool()` data: `totalDeposits`, `activeInvoiceCount`, and `totalYieldDistributed` (compact-formatted to match the existing design).
- Each stat shows a skeleton shimmer while loading and falls back to `—` when the indexer is unavailable.

### #130 — Stellar address validation in InvoiceForm is insufficient
- Replaced the `length !== 56 || !startsWith("G")` check with `StrKey.isValidEd25519PublicKey`, which verifies the base32 checksum.
- Trims surrounding whitespace before validation/submission and updates the error message.

### #140 — Docs page instantly redirects returning users without control
- Removed the `sessionStorage('docs-boot-seen')` auto-redirect and the countdown-driven `window.location` navigation.
- Returning users now always see the boot splash; navigation happens only on explicit user action via the Next.js router (`useRouter().push`).

## Verification
- `pnpm build` — compiles successfully, types valid.
- `pnpm --filter web lint` — no new warnings (only pre-existing ones in untouched files).
- `pnpm --filter web test` — 27/27 passing.

Closes #128
Closes #129
Closes #130
Closes #140