### PR TITLE
trustrove implementation

### DIFF
--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'sonner';
+import { ConfirmationDialog } from '@/components/shared/ConfirmationDialog';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -20,6 +21,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       {children}
+      <ConfirmationDialog />
       <Toaster
         position="bottom-right"
         toastOptions={{

--- a/apps/web/components/invoice/InvoiceCard.tsx
+++ b/apps/web/components/invoice/InvoiceCard.tsx
@@ -8,8 +8,9 @@ import { Button } from '@/components/ui/button';
 import { useWalletStore } from '@/store/wallet';
 import { useProfile } from '@/hooks/useProfile';
 import { motion } from 'framer-motion';
-import { Calendar, ShieldAlert, Copy, Check, Truck, Landmark, Wallet, CheckSquare, Clock, X } from 'lucide-react';
+import { Calendar, ShieldAlert, Copy, Check, Truck, Landmark, Wallet, CheckSquare, Clock } from 'lucide-react';
 import { formatAmount } from '@/lib/assets';
+import { useConfirmDialogStore } from '@/store/confirmDialog';
 
 
 interface InvoiceCardProps {
@@ -19,23 +20,17 @@ interface InvoiceCardProps {
   isSelected?: boolean;
 }
 
-interface PendingAction {
-  label: string;
-  fn: () => Promise<any>;
-  errorMsg: string;
-}
-
 export function InvoiceCard({ invoice, role, onSelect, isSelected }: InvoiceCardProps) {
   const { address } = useWalletStore();
   const { isVerified } = useProfile();
   const { listInvoice, fundInvoice, shipInvoice, confirmDelivery, repayInvoice, defaultInvoice } = useInvoices();
+  const { request: requestConfirmation } = useConfirmDialogStore();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copiedId, setCopiedId] = useState(false);
   const [copiedBuyer, setCopiedBuyer] = useState(false);
   const [discountBpsInput, setDiscountBpsInput] = useState('200'); // default 2%
   const [showListForm, setShowListForm] = useState(false);
-  const [pendingAction, setPendingAction] = useState<PendingAction | null>(null);
 
   const truncateAddr = (addr: string) => {
     if (!addr) return '';
@@ -80,23 +75,6 @@ export function InvoiceCard({ invoice, role, onSelect, isSelected }: InvoiceCard
     } finally {
       setLoading(false);
     }
-  };
-
-  // Opens the confirmation dialog instead of firing the on-chain action directly.
-  // The actual call only happens if the user hits Confirm in the dialog.
-  const requestConfirmation = (action: PendingAction) => {
-    setPendingAction(action);
-  };
-
-  const handleConfirm = async () => {
-    if (!pendingAction) return;
-    const action = pendingAction;
-    setPendingAction(null);
-    await handleAction(action.fn, action.errorMsg);
-  };
-
-  const handleCancelConfirmation = () => {
-    setPendingAction(null);
   };
 
   // Due date calculation
@@ -328,8 +306,8 @@ export function InvoiceCard({ invoice, role, onSelect, isSelected }: InvoiceCard
                 if (!isVerified) return;
                 requestConfirmation({
                   label: 'Confirm Delivery',
-                  fn: () => confirmDelivery({ invoiceId: invoice.id }),
-                  errorMsg: 'Failed to confirm delivery',
+                  invoiceId: invoice.id,
+                  fn: () => handleAction(() => confirmDelivery({ invoiceId: invoice.id }), 'Failed to confirm delivery'),
                 });
               }}
               disabled={loading || !isVerified}
@@ -349,10 +327,10 @@ export function InvoiceCard({ invoice, role, onSelect, isSelected }: InvoiceCard
                onClick={() => {
                  if (!isVerified) return;
                  requestConfirmation({
-                   label: 'Repay Invoice',
-                   fn: () => repayInvoice({ invoiceId: invoice.id }),
-                   errorMsg: 'Failed to repay invoice',
-                 });
+                  label: 'Repay Invoice',
+                  invoiceId: invoice.id,
+                  fn: () => handleAction(() => repayInvoice({ invoiceId: invoice.id }), 'Failed to repay invoice'),
+                });
                }}
                disabled={loading || !isVerified}
              >
@@ -372,8 +350,8 @@ export function InvoiceCard({ invoice, role, onSelect, isSelected }: InvoiceCard
                 if (!isVerified) return;
                 requestConfirmation({
                   label: 'Trigger Default',
-                  fn: () => defaultInvoice({ invoiceId: invoice.id }),
-                  errorMsg: 'Failed to trigger default',
+                  invoiceId: invoice.id,
+                  fn: () => handleAction(() => defaultInvoice({ invoiceId: invoice.id }), 'Failed to trigger default'),
                 });
               }}
               disabled={loading || !isVerified}
@@ -385,71 +363,6 @@ export function InvoiceCard({ invoice, role, onSelect, isSelected }: InvoiceCard
         </div>
       )}
 
-      {/* Confirmation dialog for irreversible on-chain actions.
-          Rendered once per card; only visible when pendingAction is set. */}
-      {pendingAction && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
-          onClick={(e) => {
-            e.stopPropagation();
-            handleCancelConfirmation();
-          }}
-        >
-          <div
-            className="w-full max-w-sm bg-[#0d131a] border border-border rounded-lg p-5 shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex justify-between items-start mb-4">
-              <h4 className="text-sm font-bold font-mono text-white uppercase tracking-wider">
-                Confirm {pendingAction.label}
-              </h4>
-              <button
-                onClick={handleCancelConfirmation}
-                className="text-slate-500 hover:text-slate-300 transition-colors"
-                aria-label="Close confirmation dialog"
-              >
-                <X className="w-4 h-4" />
-              </button>
-            </div>
-
-            <div className="space-y-2 mb-5 text-xs font-mono">
-              <div className="flex justify-between">
-                <span className="text-slate-500">Action:</span>
-                <span className="text-slate-200">{pendingAction.label}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-slate-500">Invoice ID:</span>
-                <span className="text-slate-200" title={invoice.id}>{truncateAddr(invoice.id)}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-slate-500">Estimated Fee:</span>
-                <span className="text-slate-200">Network fee applies</span>
-              </div>
-            </div>
-
-            <p className="text-[10px] text-amber-500/90 font-mono mb-4 leading-normal">
-              This action is irreversible once submitted on-chain. Review carefully before confirming.
-            </p>
-
-            <div className="flex gap-2">
-              <Button
-                className="flex-1 border border-border bg-transparent hover:bg-slate-900 text-slate-300 text-[10px] font-bold uppercase py-2"
-                onClick={handleCancelConfirmation}
-                disabled={loading}
-              >
-                Cancel
-              </Button>
-              <Button
-                className="flex-1 bg-rose-600 hover:bg-rose-500 text-white text-[10px] font-bold uppercase py-2"
-                onClick={handleConfirm}
-                disabled={loading}
-              >
-                {loading ? 'PROCESSING...' : 'CONFIRM'}
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
     </motion.div>
   );
 }

--- a/apps/web/components/shared/ConfirmationDialog.tsx
+++ b/apps/web/components/shared/ConfirmationDialog.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import React from 'react';
+import { X, ShieldAlert } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useConfirmDialogStore } from '@/store/confirmDialog';
+
+function truncateAddr(addr: string) {
+  if (!addr) return '';
+  return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+}
+
+export function ConfirmationDialog() {
+  const { pendingAction, cancel } = useConfirmDialogStore();
+
+  if (!pendingAction) return null;
+
+  const handleConfirm = () => {
+    const action = pendingAction;
+    cancel();
+    action.fn();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+      onClick={cancel}
+    >
+      <div
+        className="w-full max-w-sm bg-[#0d131a] border border-border rounded-lg p-5 shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex justify-between items-start mb-4">
+          <h4 className="text-sm font-bold font-mono text-white uppercase tracking-wider">
+            Confirm {pendingAction.label}
+          </h4>
+          <button
+            onClick={cancel}
+            className="text-slate-500 hover:text-slate-300 transition-colors"
+            aria-label="Close confirmation dialog"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="space-y-2 mb-5 text-xs font-mono">
+          <div className="flex justify-between">
+            <span className="text-slate-500">Action:</span>
+            <span className="text-slate-200">{pendingAction.label}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-slate-500">Invoice ID:</span>
+            <span className="text-slate-200" title={pendingAction.invoiceId}>
+              {truncateAddr(pendingAction.invoiceId)}
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-slate-500">Estimated Fee:</span>
+            <span className="text-slate-200">Network fee applies</span>
+          </div>
+        </div>
+
+        <p className="text-[10px] text-amber-500/90 font-mono mb-4 leading-normal">
+          This action is irreversible once submitted on-chain. Review carefully before confirming.
+        </p>
+
+        <div className="flex gap-2">
+          <Button
+            className="flex-1 border border-border bg-transparent hover:bg-slate-900 text-slate-300 text-[10px] font-bold uppercase py-2"
+            onClick={cancel}
+          >
+            Cancel
+          </Button>
+          <Button
+            className="flex-1 bg-rose-600 hover:bg-rose-500 text-white text-[10px] font-bold uppercase py-2"
+            onClick={handleConfirm}
+          >
+            CONFIRM
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/store/confirmDialog.ts
+++ b/apps/web/store/confirmDialog.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+
+export interface PendingAction {
+  label: string;
+  invoiceId: string;
+  fn: () => Promise<void>;
+}
+
+interface ConfirmDialogState {
+  pendingAction: PendingAction | null;
+  request: (action: PendingAction) => void;
+  cancel: () => void;
+}
+
+export const useConfirmDialogStore = create<ConfirmDialogState>((set) => ({
+  pendingAction: null,
+  request: (action) => set({ pendingAction: action }),
+  cancel: () => set({ pendingAction: null }),
+}));


### PR DESCRIPTION
## Summary

- Extracted the per-card confirmation dialog into a global `ConfirmationDialog` component mounted once in `Providers`
- Added a Zustand store (`store/confirmDialog.ts`) that holds at most one `pendingAction` — only one dialog can exist at a time
- Removed 65 lines of inline dialog JSX from `InvoiceCard`, along with local `pendingAction` state and its handlers

## Problem

Each `InvoiceCard` rendered its own `fixed inset-0 z-50` dialog internally. With multiple cards visible, triggering actions in quick succession caused dialogs to stack on top of each other with no coordination.

## What changed

- `store/confirmDialog.ts` — new Zustand store; `request(action)` replaces the queued action, `cancel()` clears it
- `components/shared/ConfirmationDialog.tsx` — singleton dialog reads from the store; closes before firing the action (preserves original close-then-execute behavior)
- `app/providers.tsx` — mounts `<ConfirmationDialog />` at app root, sibling to `<Toaster />`
- `components/invoice/InvoiceCard.tsx` — calls `useConfirmDialogStore().request(...)` instead of local state; card's `loading`/`error` state is unchanged because `fn` wraps `handleAction`

## Test plan

- [ ] Trigger "Confirm Delivery", "Repay Invoice", and "Trigger Default" — each should open the dialog cleanly
- [ ] Dismiss with Cancel, backdrop click, and X button
- [ ] Confirm an action — dialog closes immediately, card shows loading/error as before
- [ ] With multiple cards rendered, verify only one dialog is visible at a time and no stacking artifacts appear


Closes #136 
Closes #133 
Closes #137 
Closes #139 