### PR TITLE
fix: polling lifecycle, invoice validation, config banner, and simula…

### DIFF
--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'sonner';
 import { ConfirmationDialog } from '@/components/shared/ConfirmationDialog';
+import { ConfigBanner } from '@/components/shared/ConfigBanner';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -20,6 +21,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
 
   return (
     <QueryClientProvider client={queryClient}>
+      <ConfigBanner />
       {children}
       <ConfirmationDialog />
       <Toaster

--- a/apps/web/components/invoice/InvoiceForm.tsx
+++ b/apps/web/components/invoice/InvoiceForm.tsx
@@ -81,12 +81,7 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
           errMsg.includes('missing')
         ) {
           setIsFallback(true);
-          setSimDetails({
-            estimatedFeeXlm: '0.0051185',
-            functionName: 'list_for_financing',
-            expectedResult: null,
-            footprintSize: 4,
-          });
+          setSimDetails(null);
         } else {
           setSimError(errMsg);
         }
@@ -150,10 +145,17 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
         asset,
       });
 
+      if (!res.invoice_id) {
+        throw new Error('Invoice creation did not return a valid invoice ID');
+      }
+      if (!res.transaction_hash) {
+        throw new Error('Invoice creation did not return a transaction hash');
+      }
+
       const invoiceId = res.invoice_id;
 
       // Transaction 2: Immediate List
-      if (immediateList && invoiceId) {
+      if (immediateList) {
         setIsListing(true);
         // Pre-simulate list_for_financing on the newly created invoice ID before Freighter opens
         try {

--- a/apps/web/components/shared/ConfigBanner.tsx
+++ b/apps/web/components/shared/ConfigBanner.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import React from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { validateConfig } from '@/lib/config';
+
+export function ConfigBanner() {
+  const config = validateConfig();
+
+  if (config.isConfigured) return null;
+
+  const envVarLabels: Record<string, string> = {
+    NEXT_PUBLIC_INVOICE_CONTRACT_ID: 'Invoice Contract',
+    NEXT_PUBLIC_POOL_CONTRACT_ID: 'Pool Contract',
+    NEXT_PUBLIC_REGISTRY_CONTRACT_ID: 'Registry Contract',
+  };
+
+  return (
+    <div className="bg-amber-500/10 border-b border-amber-500/20 px-4 py-3">
+      <div className="max-w-6xl mx-auto flex items-start gap-3">
+        <AlertTriangle className="w-5 h-5 text-amber-500 shrink-0 mt-0.5" />
+        <div className="font-mono text-xs">
+          <p className="font-bold text-amber-400 uppercase tracking-wider mb-1">
+            Configuration Error
+          </p>
+          <p className="text-amber-400/70 leading-relaxed">
+            Missing required environment variables:{' '}
+            {config.missing
+              .map((key) => envVarLabels[key] || key)
+              .join(', ')}
+            .. Contract interactions will fail until these are configured in{' '}
+            <code className="text-amber-500 bg-black/30 px-1 rounded">.env.local</code>.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/shared/SimulationPreview.tsx
+++ b/apps/web/components/shared/SimulationPreview.tsx
@@ -48,7 +48,22 @@ export function SimulationPreview({ details, error, isLoading, isFallback }: Sim
     );
   }
 
-  if (!details) return null;
+  if (!details) {
+    if (isFallback) {
+      return (
+        <div className="bg-amber-500/5 border border-amber-500/20 rounded-lg p-4 font-mono text-xs space-y-2">
+          <div className="flex items-center gap-2 font-bold uppercase tracking-wider text-amber-500">
+            <ShieldAlert className="w-4 h-4 shrink-0" />
+            <span>Simulation Unavailable</span>
+          </div>
+          <p className="text-[11px] text-amber-400/70 leading-relaxed">
+            Live simulation data is currently unavailable. The fee shown at signing time may differ from this preview.
+          </p>
+        </div>
+      );
+    }
+    return null;
+  }
 
   return (
     <div className="bg-[#0b1219]/60 backdrop-blur border border-primary/20 rounded-lg p-4 font-mono text-xs space-y-3 shadow-[0_0_15px_rgba(0,212,170,0.02)]">

--- a/apps/web/hooks/useBalances.ts
+++ b/apps/web/hooks/useBalances.ts
@@ -69,10 +69,11 @@ export function useBalances() {
   }, [address, connected]);
 
   useEffect(() => {
+    if (!connected) return;
     fetchBalances();
     const interval = setInterval(fetchBalances, 30000);
     return () => clearInterval(interval);
-  }, [fetchBalances]);
+  }, [connected, fetchBalances]);
 
   return { balances, loading, error, refetch: fetchBalances };
 }

--- a/apps/web/lib/config.ts
+++ b/apps/web/lib/config.ts
@@ -1,0 +1,33 @@
+const REQUIRED_ENV_VARS = [
+  'NEXT_PUBLIC_INVOICE_CONTRACT_ID',
+  'NEXT_PUBLIC_POOL_CONTRACT_ID',
+  'NEXT_PUBLIC_REGISTRY_CONTRACT_ID',
+] as const;
+
+export interface ConfigValidation {
+  missing: string[];
+  isConfigured: boolean;
+}
+
+let cachedValidation: ConfigValidation | null = null;
+
+export function validateConfig(): ConfigValidation {
+  if (cachedValidation) return cachedValidation;
+
+  const missing = REQUIRED_ENV_VARS.filter(
+    (key) => !process.env[key] || process.env[key] === ''
+  );
+
+  if (missing.length > 0) {
+    console.warn(
+      `[TrusTrove] Missing required environment variables: ${missing.join(', ')}`
+    );
+  }
+
+  cachedValidation = {
+    missing,
+    isConfigured: missing.length === 0,
+  };
+
+  return cachedValidation;
+}


### PR DESCRIPTION
## Summary
- Stop balance polling interval when wallet disconnects (#131)
- Validate invoice_id and transaction_hash before proceeding to list (#132)
- Add centralized env var validation with config error banner (#134)
- Replace hardcoded fee fallback with clear "Simulation Unavailable" state (#135)
## Changes
- `hooks/useBalances.ts`: Guard interval creation with `connected` check; add `connected` to deps
- `components/invoice/InvoiceForm.tsx`: Validate createInvoice response fields; remove hardcoded simulation fallback
- `components/shared/SimulationPreview.tsx`: Render "Simulation Unavailable" message when fallback is active without data
- `lib/config.ts` (new): Centralized required env var validation with console warnings
- `components/shared/ConfigBanner.tsx` (new): App-level banner for missing configuration
- `app/providers.tsx`: Render ConfigBanner at provider level
## Testing
- Existing `useBalances.test.ts` tests remain compatible (connected state is set before hook renders)
- Type check passes (only pre-existing module resolution errors from incomplete install)

## Fixes
closes #131 
closes #132 
closes #134 
closes #135 