### PR TITLE
feat(CORS): implement CORS middleware and update environment configur…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -213,6 +213,14 @@ JWT_SECRET=change_me_before_production
 #   Source: local .env or deployment env
 JWT_EXPIRY_HOURS=24
 
+# ALLOWED_ORIGINS
+#   Layer: indexer/backend
+#   Type: comma-separated URLs
+#   Required: no
+#   Default: http://localhost:3000
+#   Source: Render or local .env
+ALLOWED_ORIGINS=https://trustrove.vercel.app,http://localhost:3000
+
 # ── Frontend-only deployment settings ────────────────────────────────────────
 # NEXT_PUBLIC_API_BASE_URL
 #   Layer: frontend

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Yield distributes to LP shares
 ## Configuration and API documentation
 
 - Root [`.env.example`](./.env.example) is the single source of truth for frontend, SDK, and Go indexer variables. It lists each variable's layer, type, required status, default value, description, and source.
+- For Render deployments, set `ALLOWED_ORIGINS` to `https://trustrove.vercel.app,http://localhost:3000` so the indexer accepts requests only from the production Vercel domain and local development origins.
 - Indexer OpenAPI documentation lives at [`docs/openapi/indexer.yaml`](./docs/openapi/indexer.yaml), including health, SEP-10 auth, invoices, events, stats, and pool endpoints.
 - Web app setup instructions live at [`apps/web/README.md`](./apps/web/README.md).
 

--- a/docs/developer-guide/environment-variables.md
+++ b/docs/developer-guide/environment-variables.md
@@ -19,6 +19,7 @@
 | `INDEXER_POLL_INTERVAL_MS` | Backend only | Soroban event poll interval | `5000` |
 | `JWT_SECRET` | Backend only | Secret for JWT signing | `your-secret-here` |
 | `JWT_EXPIRY_HOURS` | Backend only | JWT token expiry | `24` |
+| `ALLOWED_ORIGINS` | Backend only | Allowed CORS origins for the indexer API | `https://trustrove.vercel.app,http://localhost:3000` |
 
 ## Source of truth
 

--- a/indexer/api/router.go
+++ b/indexer/api/router.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -61,23 +62,29 @@ func AuthMiddleware(jwtSecret string) func(http.Handler) http.Handler {
 func CORSMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
 	originSet := make(map[string]struct{}, len(allowedOrigins))
 	for _, o := range allowedOrigins {
-		originSet[o] = struct{}{}
+		origin := strings.TrimSpace(o)
+		if origin != "" {
+			originSet[origin] = struct{}{}
+		}
 	}
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			origin := r.Header.Get("Origin")
-
-			if _, ok := originSet[origin]; ok {
-				w.Header().Set("Access-Control-Allow-Origin", origin)
-			} else if origin == "" {
-				w.Header().Set("Access-Control-Allow-Origin", "")
+			origin := strings.TrimSpace(r.Header.Get("Origin"))
+			if origin != "" {
+				if _, ok := originSet[origin]; ok {
+					w.Header().Set("Access-Control-Allow-Origin", origin)
+					w.Header().Set("Vary", "Origin")
+				} else {
+					w.WriteHeader(http.StatusForbidden)
+					return
+				}
 			}
 
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
-			if r.Method == "OPTIONS" {
+			if r.Method == http.MethodOptions {
 				w.WriteHeader(http.StatusNoContent)
 				return
 			}
@@ -100,11 +107,11 @@ func SecurityHeadersMiddleware() func(http.Handler) http.Handler {
 }
 
 type rateLimiter struct {
-	mu       sync.Mutex
-	tokens   float64
-	last     time.Time
-	rps      float64
-	burst    int
+	mu     sync.Mutex
+	tokens float64
+	last   time.Time
+	rps    float64
+	burst  int
 }
 
 func newRateLimiter(rps int, burst int) *rateLimiter {

--- a/indexer/api/router_test.go
+++ b/indexer/api/router_test.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCORSMiddleware_AllowsConfiguredOrigin(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Origin", "https://trustrove.vercel.app")
+	rr := httptest.NewRecorder()
+
+	handler := CORSMiddleware([]string{"https://trustrove.vercel.app", "http://localhost:3000"})(next)
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusTeapot {
+		t.Fatalf("expected status %d, got %d", http.StatusTeapot, rr.Code)
+	}
+
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "https://trustrove.vercel.app" {
+		t.Fatalf("expected allowed origin to be forwarded, got %q", got)
+	}
+}
+
+func TestCORSMiddleware_RejectsUnlistedOrigin(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	rr := httptest.NewRecorder()
+
+	handler := CORSMiddleware([]string{"https://trustrove.vercel.app", "http://localhost:3000"})(next)
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected status %d, got %d", http.StatusForbidden, rr.Code)
+	}
+
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("expected no CORS header for rejected origin, got %q", got)
+	}
+}

--- a/indexer/config/config.go
+++ b/indexer/config/config.go
@@ -69,7 +69,10 @@ func LoadConfig() (*Config, error) {
 		apiPort = "8080"
 	}
 
-	originsStr := os.Getenv("CORS_ALLOWED_ORIGINS")
+	originsStr := strings.TrimSpace(os.Getenv("ALLOWED_ORIGINS"))
+	if originsStr == "" {
+		originsStr = strings.TrimSpace(os.Getenv("CORS_ALLOWED_ORIGINS"))
+	}
 	var corsOrigins []string
 	if originsStr != "" {
 		for _, origin := range strings.Split(originsStr, ",") {


### PR DESCRIPTION
# Pull Request: feat(api): add CORS configuration for production Vercel domain

## Summary

Restrict the indexer API CORS policy so only the production Vercel domain and local development origins are allowed. Requests from unlisted origins now return 403 instead of being accepted.

## Changes

- Read allowed origins from the `ALLOWED_ORIGINS` environment variable.
- Fall back to the existing `CORS_ALLOWED_ORIGINS` variable for compatibility.
- Default to `http://localhost:3000` when no allowlist is provided.
- Reject requests from unlisted origins with HTTP 403 while allowing configured origins.
- Add `ALLOWED_ORIGINS=https://trustrove.vercel.app,http://localhost:3000` to `.env.example`.
- Document the Render environment variable setting in the main README and developer environment variable docs.

## Testing

- Verified by running:
  - `cd /workspaces/TrusTrove-app/indexer && go test ./...`

## Notes

This change is intended for production deployments on Render, with the Vercel frontend origin explicitly allowlisted.
closes #14