### PR TITLE
fix(web): add escape key and backdrop click dismissal to TransactionP…

### DIFF
--- a/apps/web/components/shared/TransactionPending.tsx
+++ b/apps/web/components/shared/TransactionPending.tsx
@@ -13,7 +13,22 @@ interface TransactionPendingProps {
 }
 
 export function TransactionPending({ isOpen, txHash, statusText = 'Waiting for confirmation...', onClose }: TransactionPendingProps) {
-  const overlayRef = useFocusTrap<HTMLDivElement>(isOpen, onClose ?? undefined);
+  // Only allow dismissal (Escape / backdrop click) after the transaction has
+  // completed, i.e. when txHash is available.
+  const canDismiss = Boolean(txHash && onClose);
+
+  const overlayRef = useFocusTrap<HTMLDivElement>(isOpen, canDismiss ? onClose : undefined);
+
+  // Register a global Escape-key listener that dismisses the dialog only
+  // after the transaction has completed (txHash is set).
+  React.useEffect(() => {
+    if (!canDismiss) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose!();
+    };
+    window.addEventListener('keydown', handleEscape);
+    return () => window.removeEventListener('keydown', handleEscape);
+  }, [canDismiss, onClose]);
 
   if (!isOpen) return null;
 
@@ -24,6 +39,15 @@ export function TransactionPending({ isOpen, txHash, statusText = 'Waiting for c
       aria-modal="true"
       aria-label="Transaction Pending"
       tabIndex={-1}
+      // Backdrop click dismisses the dialog only after the transaction
+      // completes. Clicks that bubble up from children are ignored.
+      onClick={(e) => {
+        if (canDismiss && e.target === e.currentTarget) onClose!();
+      }}
+      // Keyboard handler satisfies jsx-a11y/click-events-have-key-events.
+      onKeyDown={(e) => {
+        if (e.key === 'Escape' && canDismiss) onClose!();
+      }}
       className="fixed inset-0 z-50 flex items-center justify-center bg-[#080c10]/95 backdrop-blur-sm p-4"
     >
       <div className="w-full max-w-md bg-card border border-border rounded-lg p-6 flex flex-col items-center justify-center text-center shadow-[0_0_50px_rgba(0,212,170,0.05)]">


### PR DESCRIPTION
Here's a summary of the changes to apps/web/components/shared/TransactionPending.tsx:

canDismiss guard (line 18) — Derived boolean canDismiss that is true only when both txHash and onClose are present. Used everywhere to gate dismissal.
Focus trap gated (line 20) — onClose is only passed to useFocusTrap as the escape handler when canDismiss is true, preventing the focus trap from closing the dialog mid-transaction.
Window keydown listener (lines 24-31) — A useEffect registers a global Escape-key handler on window (with proper cleanup) that only fires onClose() when canDismiss is true.
Backdrop click (lines 44-46) — onClick on the overlay div that calls onClose() only when canDismiss is true and e.target === e.currentTarget (ignoring clicks that bubble from inner content).
jsx-a11y compliance (lines 48-50) — onKeyDown handler alongside onClick satisfies click-events-have-key-events. The existing role="dialog" + tabIndex={-1} already satisfy no-static-element-interactions.

Closes #138