### PR TITLE
fix(web): cancel requestAnimationFrame on unmount in AnimatedValue

### DIFF
--- a/apps/web/components/shared/DiscountCalculator.tsx
+++ b/apps/web/components/shared/DiscountCalculator.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Sparkles, TrendingUp } from "lucide-react";
 
-// Custom CountUp hook to animate numbers smoothly in an operations terminal style
 function AnimatedValue({
   value,
   suffix = "",
@@ -14,34 +13,40 @@ function AnimatedValue({
   prefix?: string;
 }) {
   const [displayValue, setDisplayValue] = useState(value);
+  const startRef = useRef(value);
+  const frameRef = useRef<number | null>(null);
+
+  startRef.current = displayValue;
 
   useEffect(() => {
-    const start = displayValue;
+    const start = startRef.current;
     const end = value;
     if (start === end) return;
 
-    const duration = 400; // ms
+    const duration = 400;
     const startTime = performance.now();
 
     const updateNumber = (now: number) => {
       const elapsed = now - startTime;
       const progress = Math.min(elapsed / duration, 1);
-
-      // Ease out quad
       const easeProgress = progress * (2 - progress);
       const current = start + (end - start) * easeProgress;
 
       setDisplayValue(current);
 
       if (progress < 1) {
-        requestAnimationFrame(updateNumber);
-      } else {
-        setDisplayValue(end);
+        frameRef.current = requestAnimationFrame(updateNumber);
       }
     };
 
-    requestAnimationFrame(updateNumber);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    frameRef.current = requestAnimationFrame(updateNumber);
+
+    return () => {
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current);
+        frameRef.current = null;
+      }
+    };
   }, [value]);
 
   return (


### PR DESCRIPTION
## Description

The `AnimatedValue` component was using `requestAnimationFrame` without proper cleanup. If the component unmounted mid-animation, the rAF callback would continue executing against a stale closure, causing a memory leak.

## Changes

- Added `frameRef` (useRef) to track the active animation frame ID for cleanup
- Added `startRef` (useRef) synced to the latest `displayValue` during render to eliminate stale closure bugs when `value` changes mid-animation
- The `useEffect` now returns a cleanup function that calls `cancelAnimationFrame` on the tracked frame ID
- Removed the `// eslint-disable-next-line react-hooks/exhaustive-deps` suppression — the effect only depends on `[value]`, reading start from the ref instead of `displayValue` state

## Acceptance Criteria

- [x] No requestAnimationFrame fires after component unmount
- [x] ESLint exhaustive-deps warning resolved
- [x] Animation still works smoothly (same ease-out quad, same duration)
- [x] No stale closure bugs — mid-animation value changes transition smoothly from the current displayed position

Closes #144