### PR TITLE
fix: add accessible labels and ARIA attributes to range sliders

### DIFF
--- a/apps/web/components/shared/DiscountCalculator.tsx
+++ b/apps/web/components/shared/DiscountCalculator.tsx
@@ -124,6 +124,7 @@ export function DiscountCalculator() {
                   </span>
                 </div>
                 <input
+                  id="discount-sme-face-value"
                   type="range"
                   min="1000"
                   max="500000"
@@ -131,6 +132,10 @@ export function DiscountCalculator() {
                   value={faceValue}
                   onChange={(e) => setFaceValue(parseInt(e.target.value))}
                   className="w-full accent-primary bg-slate-900 h-1.5 rounded"
+                  aria-label="Invoice Face Value"
+                  aria-valuenow={faceValue}
+                  aria-valuemin={1000}
+                  aria-valuemax={500000}
                 />
                 <div className="flex justify-between text-[10px] text-slate-600 font-mono">
                   <span>$1K USDC</span>
@@ -166,6 +171,7 @@ export function DiscountCalculator() {
                   </span>
                 </div>
                 <input
+                  id="discount-sme-discount-rate"
                   type="range"
                   min="0.5"
                   max="5.0"
@@ -173,6 +179,10 @@ export function DiscountCalculator() {
                   value={discountRate}
                   onChange={(e) => setDiscountRate(parseFloat(e.target.value))}
                   className="w-full accent-primary bg-slate-900 h-1.5 rounded"
+                  aria-label="Financing Discount Rate"
+                  aria-valuenow={discountRate}
+                  aria-valuemin={0.5}
+                  aria-valuemax={5.0}
                 />
                 <div className="flex justify-between text-[10px] text-slate-600 font-mono">
                   <span>0.5% (50 bps)</span>
@@ -305,6 +315,7 @@ export function DiscountCalculator() {
                   </span>
                 </div>
                 <input
+                  id="discount-lp-deposit"
                   type="range"
                   min="500"
                   max="100000"
@@ -312,6 +323,10 @@ export function DiscountCalculator() {
                   value={lpDeposit}
                   onChange={(e) => setLpDeposit(parseInt(e.target.value))}
                   className="w-full accent-primary bg-slate-900 h-1.5 rounded"
+                  aria-label="Total USDC Deposit"
+                  aria-valuenow={lpDeposit}
+                  aria-valuemin={500}
+                  aria-valuemax={100000}
                 />
                 <div className="flex justify-between text-[10px] text-slate-600 font-mono">
                   <span>$500 USDC</span>
@@ -330,6 +345,7 @@ export function DiscountCalculator() {
                   </span>
                 </div>
                 <input
+                  id="discount-lp-utilization"
                   type="range"
                   min="10"
                   max="100"
@@ -337,6 +353,10 @@ export function DiscountCalculator() {
                   value={lpUtilization}
                   onChange={(e) => setLpUtilization(parseInt(e.target.value))}
                   className="w-full accent-primary bg-slate-900 h-1.5 rounded"
+                  aria-label="Target Pool Utilization"
+                  aria-valuenow={lpUtilization}
+                  aria-valuemin={10}
+                  aria-valuemax={100}
                 />
                 <div className="flex justify-between text-[10px] text-slate-600 font-mono">
                   <span>10% (Low)</span>
@@ -356,6 +376,7 @@ export function DiscountCalculator() {
                   </span>
                 </div>
                 <input
+                  id="discount-lp-avg-discount"
                   type="range"
                   min="0.5"
                   max="5.0"
@@ -363,6 +384,10 @@ export function DiscountCalculator() {
                   value={lpAvgDiscount}
                   onChange={(e) => setLpAvgDiscount(parseFloat(e.target.value))}
                   className="w-full accent-primary bg-slate-900 h-1.5 rounded"
+                  aria-label="Avg Invoice Discount Bps"
+                  aria-valuenow={lpAvgDiscount}
+                  aria-valuemin={0.5}
+                  aria-valuemax={5.0}
                 />
                 <div className="flex justify-between text-[10px] text-slate-600 font-mono">
                   <span>0.5%</span>
@@ -379,6 +404,7 @@ export function DiscountCalculator() {
                   </span>
                 </div>
                 <input
+                  id="discount-lp-avg-maturity"
                   type="range"
                   min="15"
                   max="90"
@@ -386,6 +412,10 @@ export function DiscountCalculator() {
                   value={lpAvgMaturity}
                   onChange={(e) => setLpAvgMaturity(parseInt(e.target.value))}
                   className="w-full accent-primary bg-slate-900 h-1.5 rounded"
+                  aria-label="Avg Days to Maturity"
+                  aria-valuenow={lpAvgMaturity}
+                  aria-valuemin={15}
+                  aria-valuemax={90}
                 />
                 <div className="flex justify-between text-[10px] text-slate-600 font-mono">
                   <span>15 Days</span>

--- a/apps/web/components/shared/LpYieldCalculator.tsx
+++ b/apps/web/components/shared/LpYieldCalculator.tsx
@@ -50,6 +50,7 @@ export function LpYieldCalculator() {
             <span className="text-primary font-bold">{utilization}%</span>
           </div>
           <input
+            id="lp-yield-utilization"
             type="range"
             min="10"
             max="100"
@@ -57,6 +58,10 @@ export function LpYieldCalculator() {
             value={utilization}
             onChange={(e) => setUtilization(parseInt(e.target.value))}
             className="w-full accent-primary bg-slate-900 h-1.5 rounded"
+            aria-label="Pool Utilization"
+            aria-valuenow={utilization}
+            aria-valuemin={10}
+            aria-valuemax={100}
           />
           <div className="flex justify-between text-[10px] text-slate-600 font-mono">
             <span>10%</span>


### PR DESCRIPTION
## Description

Several range slider inputs across the app lacked programmatic labels and ARIA attributes, causing axe-core ARIA violations. Screen readers could not identify or control the sliders.

## Changes

Added `id`, `aria-label`, `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` to all 7 range inputs:

### `LpYieldCalculator.tsx`
- `lp-yield-utilization` — Pool Utilization slider

### `DiscountCalculator.tsx`
- `discount-sme-face-value` — Invoice Face Value slider
- `discount-sme-discount-rate` — Financing Discount Rate slider
- `discount-lp-deposit` — Total USDC Deposit slider
- `discount-lp-utilization` — Target Pool Utilization slider
- `discount-lp-avg-discount` — Avg Invoice Discount Bps slider
- `discount-lp-avg-maturity` — Avg Days to Maturity slider

Each `<input type="range">` now has:
- A unique `id` attribute
- An `aria-label` matching the visual label text
- `aria-valuenow` bound to the current state value
- `aria-valuemin` and `aria-valuemax` matching the `min`/`max` attributes

Native `<input type="range">` elements already support keyboard arrow navigation, so no changes were needed for keyboard operability.

## Acceptance Criteria

- [x] Each range input has a programmatically associated label
- [x] Screen reader announces current value, min, and max
- [x] Slider is operable with keyboard arrows (native behavior)
- [x] No ARIA violations reported by axe-core

Closes #147