### PR TITLE
fix(web): improve toast accessibility announcements

### DIFF
--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -25,6 +25,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
       {children}
       <ConfirmationDialog />
       <Toaster
+        containerAriaLabel="Notifications"
         position="bottom-right"
         toastOptions={{
           style: {

--- a/apps/web/lib/toast.test.tsx
+++ b/apps/web/lib/toast.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { showErrorToast, showSuccessToast } from "@/lib/toast";
+
+const successMock = vi.fn();
+const errorMock = vi.fn();
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: successMock,
+    error: errorMock,
+  },
+}));
+
+describe("toast accessibility", () => {
+  beforeEach(() => {
+    successMock.mockClear();
+    errorMock.mockClear();
+  });
+
+  it("marks success toast content atomic and adds a screen-reader prefix", () => {
+    showSuccessToast("Deposit Complete", "abc123");
+
+    expect(successMock).toHaveBeenCalledTimes(1);
+
+    const [content, options] = successMock.mock.calls[0];
+    render(<>{content}</>);
+
+    const text = screen.getByText("Deposit Complete").closest("div");
+    expect(text).toHaveAttribute("aria-atomic", "true");
+    expect(screen.getByText("Success: ", { selector: ".sr-only" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /view on stellar expert/i })).toHaveAttribute(
+      "href",
+      "https://stellar.expert/explorer/testnet/tx/abc123",
+    );
+    expect(options).toMatchObject({ duration: 5000 });
+  });
+
+  it("marks error toast content atomic and adds a screen-reader prefix", () => {
+    showErrorToast("Withdrawal Failed", new Error("Insufficient balance"));
+
+    expect(errorMock).toHaveBeenCalledTimes(1);
+
+    const [content, options] = errorMock.mock.calls[0];
+    render(<>{content}</>);
+
+    const text = screen.getByText("Withdrawal Failed").closest("div");
+    expect(text).toHaveAttribute("aria-atomic", "true");
+    expect(screen.getByText("Error: ", { selector: ".sr-only" })).toBeInTheDocument();
+    expect(screen.getByText("Insufficient balance")).toBeInTheDocument();
+    expect(options).toMatchObject({ duration: 6000 });
+  });
+});

--- a/apps/web/lib/toast.tsx
+++ b/apps/web/lib/toast.tsx
@@ -1,29 +1,60 @@
+import type { ReactNode } from "react";
 import { toast } from "sonner";
 
 const explorerUrl = (txHash: string) =>
   `https://stellar.expert/explorer/testnet/tx/${txHash}`;
 
+function ToastAnnouncement({
+  variant,
+  action,
+  children,
+}: {
+  variant: "success" | "error";
+  action: string;
+  children?: ReactNode;
+}) {
+  const prefix = variant === "error" ? "Error: " : "Success: ";
+
+  return (
+    <div aria-atomic="true" className="flex flex-col gap-1">
+      <span className="font-medium text-sm">
+        <span className="sr-only">{prefix}</span>
+        {action}
+      </span>
+      {children}
+    </div>
+  );
+}
+
 export function showSuccessToast(action: string, txHash?: string) {
-  toast.success(action, {
-    description: txHash ? (
-      <a
-        href={explorerUrl(txHash)}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-primary underline underline-offset-2 hover:text-primary/80 text-xs font-mono"
-      >
-        View on Stellar Expert →
-      </a>
-    ) : undefined,
-    duration: 5000,
-  });
+  toast.success(
+    <ToastAnnouncement variant="success" action={action}>
+      {txHash ? (
+        <a
+          href={explorerUrl(txHash)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary underline underline-offset-2 hover:text-primary/80 text-xs font-mono"
+        >
+          View on Stellar Expert →
+        </a>
+      ) : null}
+    </ToastAnnouncement>,
+    {
+      duration: 5000,
+    },
+  );
 }
 
 export function showErrorToast(action: string, error?: Error) {
-  toast.error(action, {
-    description: error?.message ? (
-      <span className="text-xs font-mono text-red-400/80">{error.message}</span>
-    ) : undefined,
-    duration: 6000,
-  });
+  toast.error(
+    <ToastAnnouncement variant="error" action={action}>
+      {error?.message ? (
+        <span className="text-xs font-mono text-red-400/80">{error.message}</span>
+      ) : null}
+    </ToastAnnouncement>,
+    {
+      duration: 6000,
+    },
+  );
 }


### PR DESCRIPTION
Closes #148

---

## Summary
- add screen-reader-only success/error prefixes to toast content
- make each toast announcement atomic while preserving existing styling
- label the toast container for assistive technologies and add focused coverage for toast accessibility markup

## Testing
- not run (per request, no dependency install in this checkout)