### PR TITLE
fix(web): non-color identifier for invoice status badge (#149)

### DIFF
--- a/apps/web/components/invoice/InvoiceStatus.tsx
+++ b/apps/web/components/invoice/InvoiceStatus.tsx
@@ -77,6 +77,7 @@ export function InvoiceStatus({ status }: InvoiceStatusProps) {
       className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[10px] font-bold font-mono tracking-wider uppercase border ${config.bg} ${config.border} ${config.text}`}
       role="status"
       aria-label={`Invoice status: ${status}`}
+      title={status}
     >
       <Icon
         className={`w-3.5 h-3.5 ${isPulsing ? "animate-pulse" : ""}`}


### PR DESCRIPTION
## Issue
Closes #149 — *Status indicators use color-only differentiation for invoice states* (Accessibility / WCAG 1.4.1 Use of Color).

## Context
Each invoice status was originally communicated through text color and a colored dot only, which red-green color-blind users cannot distinguish (e.g. Funded / Active / Confirmed).

Per-status **icons** — the primary non-color identifier required by the acceptance criteria — already landed in commit `14d844a`, and every place that shows invoice status (`InvoiceCard`, `InvoiceTable`) renders through this `InvoiceStatus` component, so the icon cue is applied app-wide.

## Change
This PR completes the remaining item from the issue's *Suggested Implementation*: a native `title` attribute carrying the status name. The status now surfaces as a hover tooltip — an extra non-color cue for sighted (including color-blind) users — without altering any styling for existing users.

```diff
       role="status"
       aria-label={`Invoice status: ${status}`}
+      title={status}
```

## Acceptance criteria
- [x] Each status has a unique non-color identifier — distinct Lucide icon per state (already shipped) + title tooltip
- [x] No WCAG 1.4.1 (Use of Color) violations — meaning conveyed by icon + text, not color alone
- [x] Existing styling preserved for sighted users — purely additive attribute
- [x] Color-blind users can distinguish all states — unique icon shapes per status

## Testing
No tests added (per request). Existing `InvoiceStatus.test.tsx` assertions are unaffected; the change is a single additive attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)