### PR TITLE
test(web): add Zustand wallet store unit tests

### DIFF
--- a/apps/web/store/wallet.test.ts
+++ b/apps/web/store/wallet.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useWalletStore } from "@/store/wallet";
+
+beforeEach(() => {
+  localStorage.clear();
+  useWalletStore.setState({
+    address: null,
+    connected: false,
+    network: null,
+    token: null,
+    role: "issuer",
+  });
+});
+
+describe("wallet store", () => {
+  it("initial state", () => {
+    const state = useWalletStore.getState();
+    expect(state.address).toBeNull();
+    expect(state.connected).toBe(false);
+    expect(state.network).toBeNull();
+    expect(state.token).toBeNull();
+    expect(state.role).toBe("issuer");
+  });
+
+  it("connect() sets address, connected, and network", () => {
+    useWalletStore.getState().connect("GA123", "testnet");
+    const state = useWalletStore.getState();
+    expect(state.address).toBe("GA123");
+    expect(state.connected).toBe(true);
+    expect(state.network).toBe("testnet");
+  });
+
+  it("connect() overwrites previous state", () => {
+    useWalletStore.getState().connect("GA123", "testnet");
+    useWalletStore.getState().connect("GA456", "mainnet");
+    const state = useWalletStore.getState();
+    expect(state.address).toBe("GA456");
+    expect(state.connected).toBe(true);
+    expect(state.network).toBe("mainnet");
+  });
+
+  it("disconnect() resets all state to defaults", () => {
+    useWalletStore.getState().connect("GA123", "testnet");
+    useWalletStore.getState().setToken("some-token");
+    useWalletStore.getState().setRole("lp");
+
+    useWalletStore.getState().disconnect();
+
+    const state = useWalletStore.getState();
+    expect(state.address).toBeNull();
+    expect(state.connected).toBe(false);
+    expect(state.network).toBeNull();
+    expect(state.token).toBeNull();
+    expect(state.role).toBe("issuer");
+  });
+
+  it("disconnect() is idempotent when already disconnected", () => {
+    useWalletStore.getState().disconnect();
+    const state = useWalletStore.getState();
+    expect(state.address).toBeNull();
+    expect(state.connected).toBe(false);
+  });
+
+  it("setAddress() sets address and connected", () => {
+    useWalletStore.getState().setAddress("GB789");
+    const state = useWalletStore.getState();
+    expect(state.address).toBe("GB789");
+    expect(state.connected).toBe(true);
+  });
+
+  it("setAddress(null) clears address and sets connected to false", () => {
+    useWalletStore.getState().connect("GA123", "testnet");
+    useWalletStore.getState().setAddress(null);
+    const state = useWalletStore.getState();
+    expect(state.address).toBeNull();
+    expect(state.connected).toBe(false);
+  });
+
+  it("setNetwork() updates network", () => {
+    useWalletStore.getState().setNetwork("futurenet");
+    expect(useWalletStore.getState().network).toBe("futurenet");
+  });
+
+  it("setNetwork(null) clears network", () => {
+    useWalletStore.getState().setNetwork("testnet");
+    useWalletStore.getState().setNetwork(null);
+    expect(useWalletStore.getState().network).toBeNull();
+  });
+
+  it("setToken() updates token", () => {
+    useWalletStore.getState().setToken("jwt-token");
+    expect(useWalletStore.getState().token).toBe("jwt-token");
+  });
+
+  it("setToken(null) clears token", () => {
+    useWalletStore.getState().setToken("jwt-token");
+    useWalletStore.getState().setToken(null);
+    expect(useWalletStore.getState().token).toBeNull();
+  });
+
+  it("setRole() accepts 'issuer'", () => {
+    useWalletStore.getState().setRole("issuer");
+    expect(useWalletStore.getState().role).toBe("issuer");
+  });
+
+  it("setRole() accepts 'buyer'", () => {
+    useWalletStore.getState().setRole("buyer");
+    expect(useWalletStore.getState().role).toBe("buyer");
+  });
+
+  it("setRole() accepts 'lp'", () => {
+    useWalletStore.getState().setRole("lp");
+    expect(useWalletStore.getState().role).toBe("lp");
+  });
+
+  it("partialize persists only address, network, and role", () => {
+    useWalletStore.getState().connect("GA123", "testnet");
+    useWalletStore.getState().setToken("jwt");
+    useWalletStore.getState().setRole("buyer");
+
+    const raw = localStorage.getItem("wallet-storage");
+    expect(raw).not.toBeNull();
+
+    const persisted = JSON.parse(raw!);
+    expect(persisted.state.address).toBe("GA123");
+    expect(persisted.state.network).toBe("testnet");
+    expect(persisted.state.role).toBe("buyer");
+    expect(persisted.state).not.toHaveProperty("connected");
+    expect(persisted.state).not.toHaveProperty("token");
+  });
+
+  it("partialize excludes token and connected from localStorage", () => {
+    useWalletStore.getState().setToken("secret");
+    const raw = localStorage.getItem("wallet-storage");
+    const persisted = JSON.parse(raw!);
+    expect(persisted.state.token).toBeUndefined();
+    expect(persisted.state.connected).toBeUndefined();
+  });
+
+  it("persist middleware stores state under correct key", () => {
+    useWalletStore.getState().connect("GA123", "testnet");
+    const raw = localStorage.getItem("wallet-storage");
+    expect(raw).not.toBeNull();
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
   },
   test: {
     environment: "jsdom",
+    environmentOptions: {
+      jsdom: {
+        url: "http://localhost",
+      },
+    },
     setupFiles: ["./vitest.setup.ts"],
     globals: true,
     alias: {

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,1 +1,17 @@
 import "@testing-library/jest-dom";
+
+const store: Record<string, string> = {};
+const localStorageMock = {
+  getItem: (key: string) => store[key] ?? null,
+  setItem: (key: string, value: string) => { store[key] = value; },
+  removeItem: (key: string) => { delete store[key]; },
+  clear: () => { for (const k in store) delete store[k]; },
+  get length() { return Object.keys(store).length; },
+  key: (i: number) => Object.keys(store)[i] ?? null,
+};
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: localStorageMock,
+  writable: true,
+  configurable: true,
+});


### PR DESCRIPTION
Close #153 


PR description:
Summary
Adds unit test coverage for the Zustand wallet store (apps/web/store/wallet.ts), including state mutations, persist middleware partialization, and edge cases.
Changes
- apps/web/store/wallet.test.ts — 17 tests covering:
- Initial state defaults
- connect() sets address, connected, and network
- Duplicate connect() calls overwrite previous state
- disconnect() resets all state to defaults (idempotent)
- setAddress() with valid and null values (connected flag behavior)
- setNetwork(), setToken() with valid and null values
- setRole() accepts all valid roles (issuer, buyer, lp)
- partialize persists only address, network, role (excludes connected, token)
- Persist middleware writes under the correct wallet-storage key
- apps/web/vitest.setup.ts — Added a global localStorage mock to fix pre-existing failures caused by zustand's persist middleware (TypeError: Cannot read properties of undefined (reading 'setItem'))
- apps/web/vitest.config.ts — Set jsdom url to http://localhost to enable localStorage in the test environment
Acceptance criteria
- All store actions tested
- Persist middleware partialization verified
- Edge cases covered (null address, duplicate connect calls, idempotent disconnect)
- Tests pass in CI
