### PR TITLE
Features/sdk base contract client

### DIFF
--- a/docs/contributing/how-to-contribute.md
+++ b/docs/contributing/how-to-contribute.md
@@ -58,3 +58,4 @@ Before opening a PR:
 
 Questions? Reach us on Telegram: **[t.me/trusttrove](https://t.me/trusttrove)**  
 Or open a discussion on GitHub.
+linked pr :77

--- a/docs/contributing/how-to-contribute.md
+++ b/docs/contributing/how-to-contribute.md
@@ -58,4 +58,4 @@ Before opening a PR:
 
 Questions? Reach us on Telegram: **[t.me/trusttrove](https://t.me/trusttrove)**  
 Or open a discussion on GitHub.
-linked pr :77
+linked pr :77 79

--- a/packages/sdk/src/base.ts
+++ b/packages/sdk/src/base.ts
@@ -129,16 +129,18 @@ async function withRetry<T>(
 
 export class BaseContractClient {
   protected contractId: string;
+  private contractInstance: Contract;
 
   constructor(contractId: string) {
     if (!contractId) {
       throw new Error("Contract ID is required");
     }
     this.contractId = contractId;
+    this.contractInstance = new Contract(contractId);
   }
 
   protected get contract(): Contract {
-    return new Contract(this.contractId);
+    return this.contractInstance;
   }
 
   protected async readContract<T>(


### PR DESCRIPTION
1. Added a private field contractInstance: Contract to BaseContractClient
2. Initialized it in the constructor (this.contractInstance = new Contract(contractId))
3. Modified the contract getter to return the cached instance instead of creating a new one every time!
This fix ensures that only one Contract instance is created per client lifecycle, reducing unnecessary object allocations!

Closes #79 