### PR TITLE
test(web): cover wallet connection error states for Freighter not installed and user rejection

### DIFF
--- a/apps/web/hooks/useWallet.test.ts
+++ b/apps/web/hooks/useWallet.test.ts
@@ -47,9 +47,9 @@ describe("useWallet", () => {
     expect(result.current.network).toBe("testnet");
   });
 
-  it("connectWallet fails", async () => {
+  it("connectWallet handles Freighter not installed error", async () => {
     vi.mocked(connectFreighter).mockRejectedValue(
-      new Error("Freighter not installed"),
+      new Error("Freighter wallet is not installed"),
     );
 
     const { result } = renderHook(() => useWallet());
@@ -58,8 +58,25 @@ describe("useWallet", () => {
       await result.current.connectWallet();
     });
 
-    expect(result.current.error).toBe("Freighter not installed");
+    expect(result.current.error).toBe("Freighter wallet is not installed");
     expect(result.current.connected).toBe(false);
+    expect(result.current.address).toBeNull();
+  });
+
+  it("connectWallet handles user rejection error", async () => {
+    vi.mocked(connectFreighter).mockRejectedValue(
+      new Error("User rejected access"),
+    );
+
+    const { result } = renderHook(() => useWallet());
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    expect(result.current.error).toBe("User rejected access");
+    expect(result.current.connected).toBe(false);
+    expect(result.current.address).toBeNull();
   });
 
   it("disconnectWallet works", async () => {


### PR DESCRIPTION
## Description

This PR adds targeted test coverage for wallet connection error states in `useWallet.test.ts`, addressing **Issue #217**. The tests cover two specific scenarios that were previously untested:

1. **Freighter not installed** — Verifies the hook correctly surfaces the `"Freighter wallet is not installed"` error message (matching the actual `freighter.ts` implementation) and transitions to a disconnected state with a null address.

2. **User rejected access** — Verifies the hook correctly surfaces the `"User rejected access"` error message (matching the Freighter API behavior) and transitions to a disconnected state with a null address.

### Changes

| File | Change |
|------|--------|
| `apps/web/hooks/useWallet.test.ts` | Replaced the generic `connectWallet fails` test with two focused, well-named test cases that each verify the error message, `connected` state, and `address` nullification after failure |

### Testing

All 5 tests in `useWallet.test.ts` pass:
- initial state
- connectWallet succeeds
- connectWallet handles Freighter not installed error ✓ (new)
- connectWallet handles user rejection error ✓ (new)
- disconnectWallet works

### Related Issues

Closes #217