### PR TITLE
a11y(web): add aria-label and aria-valuemin/valuemax/valuenow to disc…

### DIFF
--- a/apps/web/components/invoice/InvoiceForm.tsx
+++ b/apps/web/components/invoice/InvoiceForm.tsx
@@ -332,6 +332,10 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
               step="10"
               value={discountBps}
               onChange={(e) => setDiscountBps(parseInt(e.target.value))}
+              aria-label="Financing Discount Rate"
+              aria-valuemin={50}
+              aria-valuemax={500}
+              aria-valuenow={discountBps}
               className="w-full accent-primary bg-slate-900 h-2 rounded cursor-pointer touch-pan-y"
             />
             <div className="flex justify-between text-[9px] text-slate-600 font-mono">


### PR DESCRIPTION
Close #206 


PR description:
## Description

Adds `aria-label`, `aria-valuemin`, `aria-valuemax`, and `aria-valuenow` to the financing discount rate range input for WCAG compliance.

### Changes

- `apps/web/components/invoice/InvoiceForm.tsx` — Added `aria-label="Financing Discount Rate"`, `aria-valuemin={50}`, `aria-valuemax={500}`, and `aria-valuenow={discountBps}` to the discount rate `<input type="range" />`.

### Related Issue

Closes #issue-number-here

### Acceptance Criteria

- [x] Screen readers correctly identify the purpose ("Financing Discount Rate") and current value of the slider.
- [x] No new lint or type errors.