### PR TITLE
ci: fix malformed ci.yml so workflows actually run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,6 @@ jobs:
       - name: Check Formatting
         run: npx prettier --check .
 
-    - name: Check Formatting
-      run: npx prettier --check .
-
   verify-go-indexer:
     name: Verify Go Indexer & API
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

`.github/workflows/ci.yml` on `main` has a duplicated `Check Formatting` step at wrong indentation (2 spaces / job-level instead of 6 spaces / step-level). GitHub Actions can't parse the file, so every push and PR for weeks has come back as `failure` with `total_count: 0` jobs — the checks look red but nothing has actually run.

Combined with the fact that `main` has no branch protection at all (`gh api repos/.../branches/main/protection` returns `404 Branch not protected`), this meant the entire wave of merged PRs was ungated.

## What this PR does

- Deletes the stray 3-line duplicate step. No other changes.

## Follow-ups (not in this PR)

- Enable branch protection on `main` requiring `Verify TypeScript Frontend & SDK` and `Verify Go Indexer & API` — will be done after this merges and the jobs post their real check names.
- Any pre-existing test/lint/format failures the now-running CI surfaces should be filed as separate issues, not fixed here.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` passes locally.
- [ ] After merge, `gh run list` shows a completed run with 2 real jobs and their pass/fail state.