### PR TITLE
fix(web): remove orphan </Modal> tag in TransactionPending.tsx

### DIFF
--- a/apps/web/components/shared/TransactionPending.tsx
+++ b/apps/web/components/shared/TransactionPending.tsx
@@ -127,7 +127,7 @@ export function TransactionPending({
           </Button>
         )}
       </div>
-    </Modal>
+    </div>
   );
 }
 


### PR DESCRIPTION
Fixes #271

Removes orphan </Modal> closing tag that had no matching open tag (Modal was never imported). Part of the post-wave unblock series to restore `next build` on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)