### PR TITLE
fix(web): remove orphan </Modal> tag in dashboard/page.tsx

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -484,7 +484,7 @@ export default function SMEDashboard() {
             </div>
           </div>
         </div>
-      </Modal>
+      )}
     </PageLayout>
   );
 }


### PR DESCRIPTION
Fixes #270

Removes orphan </Modal> closing tag that had no matching open tag (Modal was never imported). Part of the post-wave unblock series to restore `next build` on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)