### PR TITLE
fix(web): restore useBalances.ts -- move orphan statements into function scope

### DIFF
--- a/apps/web/hooks/useBalances.ts
+++ b/apps/web/hooks/useBalances.ts
@@ -46,21 +46,15 @@ async function fetchBalancesFromHorizon(
       }
     }
 
-      setBalances({ usdc, xlm });
-    } catch (err: unknown) {
-      if (err instanceof Error && "response" in err) {
-        const resp = (err as { response?: { status: number } }).response;
-        if (resp?.status === 404) {
-          setBalances({ usdc: null, xlm: "0" });
-        } else {
-          captureError(err);
-          setError("Failed to fetch balances");
-        }
-      } else {
-        captureError(err);
-        setError("Failed to fetch balances");
+    return { usdc, xlm };
+  } catch (err: unknown) {
+    if (err instanceof Error && "response" in err) {
+      const resp = (err as { response?: { status: number } }).response;
+      if (resp?.status === 404) {
+        return { usdc: null, xlm: "0" };
       }
     }
+    captureError(err);
     throw err;
   }
 }


### PR DESCRIPTION
Fixes #266

Restores useBalances.ts after wave-era merge left orphan setter calls and `throw err;` at module top-level. Part of the post-wave unblock series to restore `next build` on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)