### PR TITLE
fix(web): resolve getUserFriendlyMessage import in useAppError

### DIFF
--- a/apps/web/lib/errors.ts
+++ b/apps/web/lib/errors.ts
@@ -52,6 +52,33 @@ function extractMessage(err: unknown): string {
   return "An unexpected error occurred";
 }
 
+const KNOWN_ERRORS: Record<string, string> = {
+  "Wallet not connected":
+    "Please connect your wallet to perform this action",
+};
+
+export function getErrorMessage(
+  error: unknown,
+  fallback = "An unexpected error occurred",
+): string {
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+  if (
+    error &&
+    typeof error === "object" &&
+    "message" in error &&
+    typeof (error as { message: unknown }).message === "string"
+  ) {
+    return (error as { message: string }).message;
+  }
+  return fallback;
+}
+
+export function getUserFriendlyMessage(error: unknown): string {
+  const message = getErrorMessage(error);
+  return KNOWN_ERRORS[message] || message;
+}
+
 export function createErrorHandler(context: string) {
   function captureError(error: unknown) {
     const type = classifyError(error);


### PR DESCRIPTION
Partial fix for #289. The `getUserFriendlyMessage` symbol imported by useAppError does not exist in @/lib/errors, causing a build-time module-resolution error. This PR restores it (or reroutes the consumer). Was blocking `pnpm build` on main after the earlier syntax fixes cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)