### PR TITLE
fix(web): escape literal quotes in app/page.tsx

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -136,7 +136,7 @@ export default function Home() {
             </div>
 
             <div className="text-xs font-mono text-slate-400 border-l-2 border-primary pl-3">
-              "From invoice to USDC in minutes. Not weeks."
+              &ldquo;From invoice to USDC in minutes. Not weeks.&rdquo;
             </div>
           </div>
 


### PR DESCRIPTION
Escapes literal " characters in JSX text on line 139 to satisfy the react/no-unescaped-entities lint rule. Was blocking `pnpm --filter web lint` on main. Purely text-level fix, no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)