### PR TITLE
fix(web): call useFocusTrap unconditionally in ConfirmationDialog

### DIFF
--- a/apps/web/components/shared/ConfirmationDialog.tsx
+++ b/apps/web/components/shared/ConfirmationDialog.tsx
@@ -13,10 +13,9 @@ function truncateAddr(addr: string) {
 
 export function ConfirmationDialog() {
   const { pendingAction, cancel } = useConfirmDialogStore();
+  const overlayRef = useFocusTrap<HTMLDivElement>(!!pendingAction, cancel);
 
   if (!pendingAction) return null;
-
-  const overlayRef = useFocusTrap<HTMLDivElement>(!!pendingAction, cancel);
 
   const handleConfirm = () => {
     const action = pendingAction;


### PR DESCRIPTION
Moves the useFocusTrap call above the early return so hooks execute in a consistent order on every render. Satisfies react-hooks/rules-of-hooks. Was blocking `pnpm --filter web lint` on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)