### PR TITLE
fix(web): resolve InvoiceForm in dynamic import (type error)

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -29,7 +29,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { formatAmount } from "@/lib/assets";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
 
-const InvoiceForm = dynamic(() => import("@/components/invoice/InvoiceForm"), {
+const InvoiceForm = dynamic(() => import("@/components/invoice/InvoiceForm").then((m) => m.InvoiceForm), {
   ssr: false,
   loading: () => (
     <div className="h-64 w-full flex items-center justify-center">


### PR DESCRIPTION
The `dynamic(() => import(...))` on dashboard/page.tsx:32 was receiving a module namespace object instead of a component. Next.js' `dynamic` needs either a default export or a promise resolving to a component. Adds `.then(m => m.InvoiceForm)` (or the default-export equivalent) so the type-check passes. Was blocking `next build` on main after the earlier fixes cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)