### PR TITLE
fix(web): resolve TransactionPending in dynamic import (type error)

### DIFF
--- a/apps/web/app/lp/page.tsx
+++ b/apps/web/app/lp/page.tsx
@@ -34,7 +34,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getPoolSnapshots } from "@/lib/api";
 import { usePoolChartData } from "@/hooks/usePoolChartData";
 
-const TransactionPending = dynamic(() => import("@/components/shared/TransactionPending"), {
+const TransactionPending = dynamic(() => import("@/components/shared/TransactionPending").then((m) => m.TransactionPending), {
   ssr: false,
   loading: () => (
     <div className="fixed inset-0 flex items-center justify-center z-50 bg-black/50">


### PR DESCRIPTION
Same pattern as #379. `dynamic(() => import(...))` needs a component, not a namespace object. Adds `.then(m => m.TransactionPending)` so the type-check passes. Was blocking `next build` on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)