### PR TITLE
fix(web): use motion.path for animated SVG line in lp/page.tsx

### DIFF
--- a/apps/web/app/lp/page.tsx
+++ b/apps/web/app/lp/page.tsx
@@ -477,7 +477,7 @@ export default function LPDashboard() {
                       <path d={chartLines.areaD} fill="url(#chartGlow)" />
 
                       {/* Line path */}
-                      <path
+                      <motion.path
                         d={chartLines.lineD}
                         fill="transparent"
                         stroke="#00d4aa"

--- a/apps/web/app/lp/page.tsx
+++ b/apps/web/app/lp/page.tsx
@@ -34,7 +34,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getPoolSnapshots } from "@/lib/api";
 import { usePoolChartData } from "@/hooks/usePoolChartData";
 
-const TransactionPending = dynamic(() => import("@/components/shared/TransactionPending"), {
+const TransactionPending = dynamic(() => import("@/components/shared/TransactionPending").then((m) => m.TransactionPending), {
   ssr: false,
   loading: () => (
     <div className="fixed inset-0 flex items-center justify-center z-50 bg-black/50">


### PR DESCRIPTION
The <path> element on lp/page.tsx:485 was receiving framer-motion props (initial/animate/transition), which aren't valid on a plain SVG path. Switching to <motion.path> so the type-check passes. Was blocking `next build` on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)