### PR TITLE
fix(web): derive isError from error in TopStatusBar

### DIFF
--- a/apps/web/app/lp/page.tsx
+++ b/apps/web/app/lp/page.tsx
@@ -477,7 +477,7 @@ export default function LPDashboard() {
                       <path d={chartLines.areaD} fill="url(#chartGlow)" />
 
                       {/* Line path */}
-                      <path
+                      <motion.path
                         d={chartLines.lineD}
                         fill="transparent"
                         stroke="#00d4aa"

--- a/apps/web/app/lp/page.tsx
+++ b/apps/web/app/lp/page.tsx
@@ -34,7 +34,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getPoolSnapshots } from "@/lib/api";
 import { usePoolChartData } from "@/hooks/usePoolChartData";
 
-const TransactionPending = dynamic(() => import("@/components/shared/TransactionPending"), {
+const TransactionPending = dynamic(() => import("@/components/shared/TransactionPending").then((m) => m.TransactionPending), {
   ssr: false,
   loading: () => (
     <div className="fixed inset-0 flex items-center justify-center z-50 bg-black/50">

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -38,11 +38,12 @@ export default function ProfilePage() {
     registerError,
   } = useProfile();
 
+  // Registration Form States
+  const [showRegModal, setShowRegModal] = useState(false);
+
   // Modal Refs
   const modalRef = useFocusTrap<HTMLDivElement>(showRegModal, () => setShowRegModal(false));
 
-  // Registration Form States
-  const [showRegModal, setShowRegModal] = useState(false);
   const [regRole, setRegRole] = useState<"issuer" | "buyer">("issuer");
   const [companyName, setCompanyName] = useState("");
   const [taxId, setTaxId] = useState("");

--- a/apps/web/components/shared/TopStatusBar.tsx
+++ b/apps/web/components/shared/TopStatusBar.tsx
@@ -57,7 +57,8 @@ const tickerItems: TickerItem[] = [
 ];
 
 export function TopStatusBar() {
-  const { events: rawEvents, isLoading, isError } = useRecentEvents(20);
+  const { events: rawEvents, isLoading, error } = useRecentEvents(20);
+  const isError = error !== null;
   const [tickerItems, setTickerItems] = useState<TickerItem[]>([]);
 
   // Format event for display in the ticker

--- a/apps/web/components/shared/TopStatusBar.tsx
+++ b/apps/web/components/shared/TopStatusBar.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import { ArrowUpRight, Pause, Play } from "lucide-react";
+import { useRecentEvents } from "@/hooks/useEvents";
 
 interface TickerItem {
   id: string;


### PR DESCRIPTION
`useRecentEvents` returns `error` (Error | null), not `isError`. Destructure error and derive isError from it. Was blocking `next build` on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)