### PR TITLE
fix(web): import EventLog type in TopStatusBar

### DIFF
--- a/apps/web/components/shared/TopStatusBar.tsx
+++ b/apps/web/components/shared/TopStatusBar.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import { ArrowUpRight, Pause, Play } from "lucide-react";
 import { useRecentEvents } from "@/hooks/useEvents";
+import type { EventLog } from "@/types";
 
 interface TickerItem {
   id: string;


### PR DESCRIPTION
Adds missing `import type { EventLog } from '@/types'`. Was blocking `next build` on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)