### PR TITLE
fix(web): add useEffect import and isPaused state in TopStatusBar

### DIFF
--- a/apps/web/components/shared/TopStatusBar.tsx
+++ b/apps/web/components/shared/TopStatusBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { ArrowUpRight, Pause, Play } from "lucide-react";
 import { useRecentEvents } from "@/hooks/useEvents";
 import type { EventLog } from "@/types";
@@ -61,6 +61,7 @@ export function TopStatusBar() {
   const { events: rawEvents, isLoading, error } = useRecentEvents(20);
   const isError = error !== null;
   const [tickerItems, setTickerItems] = useState<TickerItem[]>([]);
+  const [isPaused, setIsPaused] = useState(false);
 
   // Format event for display in the ticker
   const formatEventForTicker = (event: EventLog): TickerItem => {


### PR DESCRIPTION
Adds missing `useEffect` import and `isPaused`/`setIsPaused` state declaration in TopStatusBar. Was blocking `next build` on main.

