### PR TITLE
fix(web): restore initApiClientWithToken helper for useAuth

### DIFF
--- a/apps/web/hooks/useAuth.ts
+++ b/apps/web/hooks/useAuth.ts
@@ -1,7 +1,11 @@
 import { useState } from "react";
 import { useWalletStore } from "@/store/wallet";
 import { signTransaction } from "@stellar/freighter-api";
-import { fetchChallenge, verifyChallenge } from "@/lib/api";
+import {
+  fetchChallenge,
+  verifyChallenge,
+  initApiClientWithToken,
+} from "@/lib/api";
 import { createErrorHandler } from "@/lib/errors";
 
 const { captureError } = createErrorHandler("useAuth");


### PR DESCRIPTION
Restores initApiClientWithToken (from history, adapted to the class-based ApiClient introduced in #373). useAuth.ts was calling it in 3 places but the symbol had been dropped. Was blocking `next build` on main.