### PR TITLE
fix(web): add useTokenAllowance imports and fix usePool mutation type

### DIFF
--- a/apps/web/hooks/useInvoices.ts
+++ b/apps/web/hooks/useInvoices.ts
@@ -10,6 +10,7 @@ import { InvoiceClient, PoolClient } from "@trusttrove/sdk";
 import { useWalletStore } from "@/store/wallet";
 import { showSuccessToast } from "@/lib/toast";
 import { createErrorHandler } from "@/lib/errors";
+import { useTokenAllowance } from "./useTokenAllowance";
 
 const { handleMutationError } = createErrorHandler("useInvoices");
 

--- a/apps/web/hooks/usePool.ts
+++ b/apps/web/hooks/usePool.ts
@@ -5,6 +5,7 @@ import { PoolClient } from "@trusttrove/sdk";
 import { useWalletStore } from "@/store/wallet";
 import { showSuccessToast } from "@/lib/toast";
 import { createErrorHandler } from "@/lib/errors";
+import { useTokenAllowance } from "./useTokenAllowance";
 
 const { handleMutationError } = createErrorHandler("usePool");
 


### PR DESCRIPTION
Two related fixes needed to unblock `next build` on main:

1. hooks/useInvoices.ts and hooks/usePool.ts referenced `useTokenAllowance` but did not import it. Adds the missing imports.
2. hooks/usePool.ts:68 had a useMutation generic mismatch (declared string, returned bigint). Aligned the types.

Companion to the SDK PR that restores TokenClient (which useTokenAllowance itself imports).