### PR TITLE
fix(web): add totalShares to parseRawPoolStats

### DIFF
--- a/apps/web/lib/transformers.ts
+++ b/apps/web/lib/transformers.ts
@@ -56,6 +56,7 @@ function parseRawPoolStats(raw: any): PoolStats {
     utilizationRateBps: Number(raw.utilization_rate_bps || 0),
     totalYieldDistributed: BigInt(raw.total_yield_distributed || 0),
     activeInvoiceCount: Number(raw.active_invoice_count || 0),
+    totalShares: BigInt(raw.total_shares || 0),
   };
 }
 


### PR DESCRIPTION
PoolStats requires a totalShares field but parseRawPoolStats was not populating it. Adds `totalShares: BigInt(raw.total_shares || 0)`. Was blocking `next build` on main.