### PR TITLE
fix(indexer): propagate context through Soroban RPC calls for gracefu…

### DIFF
--- a/indexer/api/handlers.go
+++ b/indexer/api/handlers.go
@@ -93,7 +93,7 @@ type JsonRpcResponse struct {
 	} `json:"error"`
 }
 
-func CallSorobanRPC(rpcURL string, method string, params interface{}, result interface{}) error {
+func CallSorobanRPC(ctx context.Context, rpcURL string, method string, params interface{}, result interface{}) error {
 	reqBody := JsonRpcRequest{
 		Jsonrpc: "2.0",
 		Id:      1,
@@ -106,7 +106,13 @@ func CallSorobanRPC(rpcURL string, method string, params interface{}, result int
 		return err
 	}
 
-	resp, err := http.Post(rpcURL, "application/json", bytes.NewBuffer(bodyBytes))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rpcURL, bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -223,6 +229,7 @@ type GetAccountResponse struct {
 }
 
 func ReadContract(
+	ctx context.Context,
 	rpcURL string,
 	contractID string,
 	method string,
@@ -256,7 +263,7 @@ func ReadContract(
 	}
 
 	var simResp SimulateResponse
-	err = CallSorobanRPC(rpcURL, "simulateTransaction", map[string]string{"transaction": txBase64}, &simResp)
+	err = CallSorobanRPC(ctx, rpcURL, "simulateTransaction", map[string]string{"transaction": txBase64}, &simResp)
 	if err != nil {
 		return xdr.ScVal{}, err
 	}
@@ -505,7 +512,7 @@ func (h *APIHandler) HandleCreateInvoice(w http.ResponseWriter, r *http.Request)
 	}
 
 	var accResp GetAccountResponse
-	err := CallSorobanRPC(h.cfg.SorobanRPCURL, "getAccount", map[string]string{"address": h.serverKP.Address()}, &accResp)
+	err := CallSorobanRPC(r.Context(), h.cfg.SorobanRPCURL, "getAccount", map[string]string{"address": h.serverKP.Address()}, &accResp)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to fetch server account: %s", err.Error()), http.StatusInternalServerError)
 		return
@@ -560,7 +567,7 @@ func (h *APIHandler) HandleCreateInvoice(w http.ResponseWriter, r *http.Request)
 	}
 
 	var simResp SimulateResponse
-	err = CallSorobanRPC(h.cfg.SorobanRPCURL, "simulateTransaction", map[string]string{"transaction": txBase64}, &simResp)
+	err = CallSorobanRPC(r.Context(), h.cfg.SorobanRPCURL, "simulateTransaction", map[string]string{"transaction": txBase64}, &simResp)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("simulation failed: %s", err.Error()), http.StatusInternalServerError)
 		return
@@ -639,7 +646,7 @@ func (h *APIHandler) HandleCreateInvoice(w http.ResponseWriter, r *http.Request)
 		Status string `json:"status"`
 		Error  string `json:"error"`
 	}
-	err = CallSorobanRPC(h.cfg.SorobanRPCURL, "sendTransaction", map[string]string{"transaction": signedBase64}, &submitResp)
+	err = CallSorobanRPC(r.Context(), h.cfg.SorobanRPCURL, "sendTransaction", map[string]string{"transaction": signedBase64}, &submitResp)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to send transaction: %s", err.Error()), http.StatusInternalServerError)
 		return
@@ -661,7 +668,7 @@ func (h *APIHandler) HandleCreateInvoice(w http.ResponseWriter, r *http.Request)
 	pollAttempts := 0
 
 	for {
-		err = CallSorobanRPC(h.cfg.SorobanRPCURL, "getTransaction", map[string]string{"hash": submitResp.Hash}, &txResult)
+		err = CallSorobanRPC(r.Context(), h.cfg.SorobanRPCURL, "getTransaction", map[string]string{"hash": submitResp.Hash}, &txResult)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("failed to poll transaction: %s", err.Error()), http.StatusInternalServerError)
 			return
@@ -890,7 +897,7 @@ func (h *APIHandler) HandleGetLPPosition(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	scValResult, err := ReadContract(h.cfg.SorobanRPCURL, h.cfg.PoolContractID, "get_lp_position", []xdr.ScVal{addrVal}, h.serverKP)
+	scValResult, err := ReadContract(r.Context(), h.cfg.SorobanRPCURL, h.cfg.PoolContractID, "get_lp_position", []xdr.ScVal{addrVal}, h.serverKP)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to read LP position from pool: %s", err.Error()), http.StatusInternalServerError)
 		return

--- a/indexer/listener/handlers.go
+++ b/indexer/listener/handlers.go
@@ -21,7 +21,7 @@ func SyncPoolStats(ctx context.Context, cfg *config.Config, serverKP *keypair.Fu
 	slog.Info("Syncing pool stats from chain...")
 
 	// Read stats from pool contract on-chain
-	scValResult, err := api.ReadContract(cfg.SorobanRPCURL, cfg.PoolContractID, "get_stats", []xdr.ScVal{}, serverKP)
+	scValResult, err := api.ReadContract(ctx, cfg.SorobanRPCURL, cfg.PoolContractID, "get_stats", []xdr.ScVal{}, serverKP)
 	if err != nil {
 		return fmt.Errorf("sync pool stats: read contract: %w", err)
 	}

--- a/indexer/listener/soroban.go
+++ b/indexer/listener/soroban.go
@@ -84,7 +84,7 @@ func NewEventListener(cfg *config.Config, health *api.ListenerHealth) *EventList
 // getLatestLedgerSequence fetches the latest ledger sequence number from the Soroban RPC
 func (l *EventListener) getLatestLedgerSequence(ctx context.Context) (int32, error) {
 	var res GetLatestLedgerResult
-	err := api.CallSorobanRPC(l.cfg.SorobanRPCURL, "getLatestLedger", nil, &res)
+	err := api.CallSorobanRPC(ctx, l.cfg.SorobanRPCURL, "getLatestLedger", nil, &res)
 	if err != nil {
 		return 0, fmt.Errorf("call getLatestLedger: %w", err)
 	}
@@ -209,7 +209,7 @@ func (l *EventListener) pollEvents(ctx context.Context, startLedger int32) (int3
 		}
 
 		var res GetEventsResult
-		err := api.CallSorobanRPC(l.cfg.SorobanRPCURL, "getEvents", params, &res)
+		err := api.CallSorobanRPC(ctx, l.cfg.SorobanRPCURL, "getEvents", params, &res)
 		if err != nil {
 			return startLedger, fmt.Errorf("call getEvents (startLedger=%d, cursor=%s): %w", startLedger, cursor, err)
 		}


### PR DESCRIPTION
…l shutdown

Replace http.Post with http.NewRequestWithContext in CallSorobanRPC so that in-flight Soroban RPC calls respect context cancellation. Add ctx parameter to CallSorobanRPC and ReadContract, and update all callers to propagate their respective contexts (listener cancellable ctx, HTTP request r.Context()).

Done. Branch `fix/context-propagation-listener` is ready. Here's what was changed across 3 files:

**`indexer/api/handlers.go`** — Core fix:
- `CallSorobanRPC` now accepts `ctx context.Context` as the first parameter
- Replaced `http.Post` with `http.NewRequestWithContext` + `http.DefaultClient.Do` so in-flight RPC calls respect cancellation
- `ReadContract` also accepts and propagates `ctx`
- All HTTP handler callers pass `r.Context()`

**`indexer/listener/soroban.go`** — Listener fix:
- `getLatestLedgerSequence` now passes its `ctx` through to `CallSorobanRPC` (line 87)
- `pollEvents` passes `ctx` to `CallSorobanRPC` for `getEvents` (line 212)

**`indexer/listener/handlers.go`** — Handler fix:
- `SyncPoolStats` passes `ctx` to `ReadContract`

**Verification:**
- `go build -v ./...` — clean
- `go vet ./...` — clean
- `go test -v ./...` — all tests pass
- `gofmt -l .` — no output (clean formatting)

To push and open a PR:
```
git push -u origin fix/context-propagation-listener
gh pr create --title "fix(indexer): propagate context through Soroban RPC calls for graceful shutdown" --body "Closes #"
```

Closes #324
Closes #326
Closes #328
Closes #325