### PR TITLE
fix(web): distinguish user-rejected vs other Freighter errors in conn…

### DIFF
--- a/apps/web/components/shared/WalletConnect.test.tsx
+++ b/apps/web/components/shared/WalletConnect.test.tsx
@@ -24,6 +24,14 @@ vi.mock("@/hooks/useWallet", () => {
 
 vi.mock("@/lib/freighter", () => ({
   isFreighterInstalled: vi.fn().mockResolvedValue(true),
+  FreighterError: class FreighterError extends Error {
+    readonly code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.name = "FreighterError";
+      this.code = code;
+    }
+  },
 }));
 
 beforeEach(() => {
@@ -75,9 +83,54 @@ describe("WalletConnect", () => {
       loading: false,
       address: null,
       error: "Connection failed",
+      errorCode: null,
     } as any);
     render(<WalletConnect />);
     expect(screen.getByText(/Connection failed/i)).toBeInTheDocument();
+  });
+
+  it("renders user-rejected message when errorCode is user_rejected", async () => {
+    vi.mocked(useWallet).mockReturnValue({
+      connected: false,
+      loading: false,
+      address: null,
+      error: "The user rejected this request.",
+      errorCode: "user_rejected",
+    } as any);
+    render(<WalletConnect />);
+    expect(
+      await screen.findByText(/You cancelled the connection request/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders install CTA when errorCode is not_installed", async () => {
+    vi.mocked(useWallet).mockReturnValue({
+      connected: false,
+      loading: false,
+      address: null,
+      error: "Freighter wallet is not installed",
+      errorCode: "not_installed",
+    } as any);
+    render(<WalletConnect />);
+
+    const installLink = await screen.findByText(/Install Freighter/i);
+    expect(installLink).toBeInTheDocument();
+    expect(installLink.closest("a")).toHaveAttribute(
+      "href",
+      "https://www.freighter.app/",
+    );
+  });
+
+  it("renders generic error for errorCode unknown", () => {
+    vi.mocked(useWallet).mockReturnValue({
+      connected: false,
+      loading: false,
+      address: null,
+      error: "Something went wrong",
+      errorCode: "unknown",
+    } as any);
+    render(<WalletConnect />);
+    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
   });
 
   it("renders install prompt when Freighter is not installed", async () => {

--- a/apps/web/components/shared/WalletConnect.tsx
+++ b/apps/web/components/shared/WalletConnect.tsx
@@ -23,6 +23,7 @@ export function WalletConnect() {
     disconnectWallet,
     loading,
     error: walletError,
+    errorCode,
   } = useWallet();
 
   const { network } = useWalletStore();
@@ -135,7 +136,26 @@ export function WalletConnect() {
         )}
       </div>
 
-      {walletError && (
+      {walletError && errorCode === "user_rejected" && (
+        <div className="flex items-center gap-1.5 text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-md px-2.5 py-1">
+          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate max-w-xs">You cancelled the connection request</span>
+        </div>
+      )}
+
+      {walletError && errorCode === "not_installed" && (
+        <a
+          href="https://www.freighter.app/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-md px-2.5 py-1 hover:bg-amber-500/20 transition-all"
+        >
+          <span>Install Freighter</span>
+          <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+      )}
+
+      {walletError && errorCode !== "user_rejected" && errorCode !== "not_installed" && (
         <div className="flex items-center gap-1.5 text-xs text-rose-400 bg-rose-500/10 border border-rose-500/20 rounded-md px-2.5 py-1">
           <AlertCircle className="h-3.5 w-3.5 shrink-0" />
           <span className="truncate max-w-xs">{walletError}</span>

--- a/apps/web/hooks/useWallet.test.ts
+++ b/apps/web/hooks/useWallet.test.ts
@@ -2,11 +2,22 @@ import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useWallet } from "./useWallet";
 import { useWalletStore } from "@/store/wallet";
-import { connectFreighter } from "@/lib/freighter";
+import {
+  connectFreighter,
+  FreighterError,
+} from "@/lib/freighter";
 import { useBalances } from "./useBalances";
 
 vi.mock("@/lib/freighter", () => ({
   connectFreighter: vi.fn(),
+  FreighterError: class FreighterError extends Error {
+    readonly code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.name = "FreighterError";
+      this.code = code;
+    }
+  },
 }));
 
 vi.mock("./useBalances", () => ({
@@ -139,6 +150,85 @@ describe("useWallet", () => {
     expect(result.current.error).toBe("Freighter wallet is not installed");
     expect(result.current.connected).toBe(false);
     expect(result.current.address).toBeNull();
+  });
+
+  it("sets errorCode to user_rejected when user rejects", async () => {
+    const mockFreighterError = new FreighterError(
+      "user_rejected",
+      "The user rejected this request.",
+    );
+    vi.mocked(connectFreighter).mockRejectedValue(mockFreighterError);
+
+    const { result } = renderHook(() => useWallet());
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    expect(result.current.error).toBe("The user rejected this request.");
+    expect(result.current.errorCode).toBe("user_rejected");
+    expect(result.current.connected).toBe(false);
+    expect(result.current.address).toBeNull();
+  });
+
+  it("sets errorCode to not_installed when Freighter is not installed", async () => {
+    const mockFreighterError = new FreighterError(
+      "not_installed",
+      "Freighter wallet is not installed",
+    );
+    vi.mocked(connectFreighter).mockRejectedValue(mockFreighterError);
+
+    const { result } = renderHook(() => useWallet());
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    expect(result.current.error).toBe("Freighter wallet is not installed");
+    expect(result.current.errorCode).toBe("not_installed");
+    expect(result.current.connected).toBe(false);
+    expect(result.current.address).toBeNull();
+  });
+
+  it("sets errorCode to unknown for unmapped Freighter errors", async () => {
+    const mockFreighterError = new FreighterError(
+      "unknown",
+      "Unexpected failure",
+    );
+    vi.mocked(connectFreighter).mockRejectedValue(mockFreighterError);
+
+    const { result } = renderHook(() => useWallet());
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+
+    expect(result.current.error).toBe("Unexpected failure");
+    expect(result.current.errorCode).toBe("unknown");
+    expect(result.current.connected).toBe(false);
+  });
+
+  it("clears errorCode on successful connection", async () => {
+    const mockFreighterError = new FreighterError(
+      "user_rejected",
+      "The user rejected this request.",
+    );
+    vi.mocked(connectFreighter)
+      .mockRejectedValueOnce(mockFreighterError)
+      .mockResolvedValueOnce("G12345");
+
+    const { result } = renderHook(() => useWallet());
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+    expect(result.current.errorCode).toBe("user_rejected");
+
+    await act(async () => {
+      await result.current.connectWallet();
+    });
+    expect(result.current.errorCode).toBeNull();
+    expect(result.current.connected).toBe(true);
   });
 
   it("disconnectWallet works", () => {

--- a/apps/web/hooks/useWallet.ts
+++ b/apps/web/hooks/useWallet.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useWalletStore } from "@/store/wallet";
-import { connectFreighter } from "@/lib/freighter";
+import { connectFreighter, FreighterError } from "@/lib/freighter";
 import { useBalances } from "./useBalances";
 import { createErrorHandler } from "@/lib/errors";
 
@@ -31,6 +31,7 @@ export function useWallet() {
   const { address, connected, network, connect, disconnect } = useWalletStore();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<string | null>(null);
   const {
     balances,
     loading: balancesLoading,
@@ -48,12 +49,16 @@ export function useWallet() {
   const connectWallet = async () => {
     setLoading(true);
     setError(null);
+    setErrorCode(null);
     try {
       const addr = await connectFreighter();
       connect(addr, "testnet");
     } catch (err: unknown) {
       const appError = captureError(err);
       setError(appError.message);
+      if (err instanceof FreighterError) {
+        setErrorCode(err.code);
+      }
       disconnect();
     } finally {
       setLoading(false);
@@ -75,6 +80,7 @@ export function useWallet() {
     disconnectWallet,
     loading,
     error,
+    errorCode,
     balances,
     balancesLoading,
     balancesError,

--- a/apps/web/lib/freighter.test.ts
+++ b/apps/web/lib/freighter.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  isFreighterInstalled,
+  connectFreighter,
+  getFreighterPublicKey,
+  FreighterError,
+} from "./freighter";
+
+vi.mock("@stellar/freighter-api", () => ({
+  isConnected: vi.fn(),
+  requestAccess: vi.fn(),
+  getPublicKey: vi.fn(),
+}));
+
+import {
+  isConnected,
+  requestAccess,
+  getPublicKey,
+} from "@stellar/freighter-api";
+
+const mockIsConnected = vi.mocked(isConnected);
+const mockRequestAccess = vi.mocked(requestAccess);
+const mockGetPublicKey = vi.mocked(getPublicKey);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("FreighterError", () => {
+  it("has code and message", () => {
+    const err = new FreighterError("user_rejected", "The user rejected this request.");
+    expect(err.code).toBe("user_rejected");
+    expect(err.message).toBe("The user rejected this request.");
+    expect(err.name).toBe("FreighterError");
+  });
+});
+
+describe("isFreighterInstalled", () => {
+  it("returns true when connected", async () => {
+    mockIsConnected.mockResolvedValue(true);
+    expect(await isFreighterInstalled()).toBe(true);
+  });
+
+  it("returns false when not connected", async () => {
+    mockIsConnected.mockResolvedValue(false);
+    expect(await isFreighterInstalled()).toBe(false);
+  });
+
+  it("returns false on error", async () => {
+    mockIsConnected.mockRejectedValue(new Error("Extension not found"));
+    expect(await isFreighterInstalled()).toBe(false);
+  });
+});
+
+describe("connectFreighter", () => {
+  it("returns the public key on success", async () => {
+    mockIsConnected.mockResolvedValue(true);
+    mockRequestAccess.mockResolvedValue("G12345");
+
+    const result = await connectFreighter();
+    expect(result).toBe("G12345");
+  });
+
+  it("throws FreighterError with not_installed when Freighter is not installed", async () => {
+    mockIsConnected.mockResolvedValue(false);
+
+    await expect(connectFreighter()).rejects.toThrow(FreighterError);
+    try {
+      await connectFreighter();
+    } catch (err) {
+      expect(err).toBeInstanceOf(FreighterError);
+      expect((err as FreighterError).code).toBe("not_installed");
+    }
+  });
+
+  it("throws FreighterError with user_rejected when user rejects", async () => {
+    mockIsConnected.mockResolvedValue(true);
+    mockRequestAccess.mockRejectedValue(
+      new Error("The user rejected this request."),
+    );
+
+    await expect(connectFreighter()).rejects.toThrow(FreighterError);
+    try {
+      await connectFreighter();
+    } catch (err) {
+      expect(err).toBeInstanceOf(FreighterError);
+      expect((err as FreighterError).code).toBe("user_rejected");
+    }
+  });
+
+  it("throws FreighterError with not_installed when Freighter returns internal error", async () => {
+    mockIsConnected.mockResolvedValue(true);
+    mockRequestAccess.mockRejectedValue(
+      new Error("The wallet encountered an internal error"),
+    );
+
+    await expect(connectFreighter()).rejects.toThrow(FreighterError);
+    try {
+      await connectFreighter();
+    } catch (err) {
+      expect(err).toBeInstanceOf(FreighterError);
+      expect((err as FreighterError).code).toBe("not_installed");
+    }
+  });
+
+  it("throws FreighterError with unknown for unexpected errors", async () => {
+    mockIsConnected.mockResolvedValue(true);
+    mockRequestAccess.mockRejectedValue(new Error("Something unexpected"));
+
+    await expect(connectFreighter()).rejects.toThrow(FreighterError);
+    try {
+      await connectFreighter();
+    } catch (err) {
+      expect(err).toBeInstanceOf(FreighterError);
+      expect((err as FreighterError).code).toBe("unknown");
+    }
+  });
+
+  it("throws FreighterError with unknown for non-Error rejections", async () => {
+    mockIsConnected.mockResolvedValue(true);
+    mockRequestAccess.mockRejectedValue("random string error");
+
+    await expect(connectFreighter()).rejects.toThrow(FreighterError);
+    try {
+      await connectFreighter();
+    } catch (err) {
+      expect(err).toBeInstanceOf(FreighterError);
+      expect((err as FreighterError).code).toBe("unknown");
+    }
+  });
+});
+
+describe("getFreighterPublicKey", () => {
+  it("returns the public key on success", async () => {
+    mockIsConnected.mockResolvedValue(true);
+    mockGetPublicKey.mockResolvedValue("G12345");
+
+    const result = await getFreighterPublicKey();
+    expect(result).toBe("G12345");
+  });
+
+  it("throws FreighterError with not_installed when Freighter is not installed", async () => {
+    mockIsConnected.mockResolvedValue(false);
+
+    await expect(getFreighterPublicKey()).rejects.toThrow(FreighterError);
+    try {
+      await getFreighterPublicKey();
+    } catch (err) {
+      expect(err).toBeInstanceOf(FreighterError);
+      expect((err as FreighterError).code).toBe("not_installed");
+    }
+  });
+
+  it("throws FreighterError with user_rejected when user rejects", async () => {
+    mockIsConnected.mockResolvedValue(true);
+    mockGetPublicKey.mockRejectedValue(
+      new Error("The user rejected this request."),
+    );
+
+    await expect(getFreighterPublicKey()).rejects.toThrow(FreighterError);
+    try {
+      await getFreighterPublicKey();
+    } catch (err) {
+      expect(err).toBeInstanceOf(FreighterError);
+      expect((err as FreighterError).code).toBe("user_rejected");
+    }
+  });
+
+  it("throws FreighterError with unknown for unexpected errors", async () => {
+    mockIsConnected.mockResolvedValue(true);
+    mockGetPublicKey.mockRejectedValue(new Error("Network unreachable"));
+
+    await expect(getFreighterPublicKey()).rejects.toThrow(FreighterError);
+    try {
+      await getFreighterPublicKey();
+    } catch (err) {
+      expect(err).toBeInstanceOf(FreighterError);
+      expect((err as FreighterError).code).toBe("unknown");
+    }
+  });
+});

--- a/apps/web/lib/freighter.ts
+++ b/apps/web/lib/freighter.ts
@@ -4,6 +4,42 @@ import {
   getPublicKey,
 } from "@stellar/freighter-api";
 
+export type FreighterErrorCode = "user_rejected" | "not_installed" | "unknown";
+
+export class FreighterError extends Error {
+  readonly code: FreighterErrorCode;
+  constructor(code: FreighterErrorCode, message: string) {
+    super(message);
+    this.name = "FreighterError";
+    this.code = code;
+  }
+}
+
+function classifyFreighterError(err: unknown): FreighterErrorCode {
+  if (err instanceof FreighterError) return err.code;
+  if (err instanceof Error) {
+    const msg = err.message.toLowerCase();
+    if (
+      msg.includes("user rejected") ||
+      msg.includes("user rejected this request")
+    ) {
+      return "user_rejected";
+    }
+    if (msg.includes("not installed") || msg.includes("internal error")) {
+      return "not_installed";
+    }
+  }
+  return "unknown";
+}
+
+function mapFreighterError(err: unknown): FreighterError {
+  if (err instanceof FreighterError) return err;
+  const code = classifyFreighterError(err);
+  const message =
+    err instanceof Error ? err.message : String(err);
+  return new FreighterError(code, message);
+}
+
 export async function isFreighterInstalled(): Promise<boolean> {
   try {
     const res = await isConnected();
@@ -20,7 +56,7 @@ export async function isFreighterInstalled(): Promise<boolean> {
 export async function connectFreighter(): Promise<string> {
   const installed = await isFreighterInstalled();
   if (!installed) {
-    throw new Error("Freighter wallet is not installed");
+    throw new FreighterError("not_installed", "Freighter wallet is not installed");
   }
 
   try {
@@ -32,19 +68,19 @@ export async function connectFreighter(): Promise<string> {
       return (res as any).address;
     }
     if ((res as any)?.error) {
-      throw new Error((res as any).error);
+      throw mapFreighterError(new Error((res as any).error));
     }
-    throw new Error("No address returned from Freighter");
+    throw new FreighterError("unknown", "No address returned from Freighter");
   } catch (err) {
     console.error("Failed to connect to Freighter:", err);
-    throw err;
+    throw mapFreighterError(err);
   }
 }
 
 export async function getFreighterPublicKey(): Promise<string> {
   const installed = await isFreighterInstalled();
   if (!installed) {
-    throw new Error("Freighter wallet is not installed");
+    throw new FreighterError("not_installed", "Freighter wallet is not installed");
   }
 
   try {
@@ -55,9 +91,9 @@ export async function getFreighterPublicKey(): Promise<string> {
     if (res && typeof res === "object" && "address" in res) {
       return (res as { address: string }).address;
     }
-    throw new Error("No public key returned from Freighter");
+    throw new FreighterError("unknown", "No public key returned from Freighter");
   } catch (err) {
     console.error("Failed to get public key from Freighter:", err);
-    throw err;
+    throw mapFreighterError(err);
   }
 }


### PR DESCRIPTION
…ectFreighter

Add FreighterError class with code field (user_rejected|not_installed|unknown) so callers can render type-specific UI:
- User rejection shows 'You cancelled the connection request'
- Not-installed shows an install-Freighter CTA link
- Unknown errors show a generic message and are logged

Changes:
- apps/web/lib/freighter.ts: Add FreighterErrorCode type and FreighterError class; map Freighter errors by message content
- apps/web/hooks/useWallet.ts: Thread error code through errorCode state
- apps/web/components/shared/WalletConnect.tsx: Switch on errorCode for toast rendering
- apps/web/lib/freighter.test.ts: New unit tests for all error cases
- apps/web/hooks/useWallet.test.ts: Tests for errorCode propagation
- apps/web/components/shared/WalletConnect.test.tsx: Tests for error code UI rendering

Closes #274