### PR TITLE
feat/invoice-list

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -16,13 +16,7 @@ import {
   InvoiceTableSkeleton,
   ActivityTimelineSkeleton,
 } from "@/components/shared/SkeletonLoader";
-import {
-  Layers,
-  Plus,
-  CheckCircle2,
-  Circle,
-  Lock,
-} from "lucide-react";
+import { Layers, Plus, CheckCircle2, Circle, Lock } from "lucide-react";
 import { Invoice } from "@/types";
 import { motion, AnimatePresence } from "framer-motion";
 import { formatAmount } from "@/lib/assets";

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import { PageLayout } from "@/components/shared/PageLayout";
@@ -19,7 +19,6 @@ import {
 import {
   Layers,
   Plus,
-  ShieldAlert,
   CheckCircle2,
   Circle,
   Lock,
@@ -43,7 +42,13 @@ const InvoiceForm = dynamic(
 
 export default function SMEDashboard() {
   const { address, connected, role } = useWalletStore();
-  const { invoices, isLoading } = useInvoices({ issuer: address || undefined });
+  const [invoicePage, setInvoicePage] = useState(1);
+  const [invoiceLimit, setInvoiceLimit] = useState(20);
+  const { invoices, isLoading, total, totalPages } = useInvoices({
+    issuer: address || undefined,
+    page: invoicePage,
+    limit: invoiceLimit,
+  });
   const { events, isLoading: eventsLoading } = useRecentEvents(10);
   const [selectedInvoice, setSelectedInvoice] = useState<Invoice | null>(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
@@ -51,6 +56,10 @@ export default function SMEDashboard() {
   const createModalRef = useFocusTrap<HTMLDivElement>(showCreateModal, () =>
     setShowCreateModal(false),
   );
+
+  useEffect(() => {
+    setSelectedInvoice(null);
+  }, [invoicePage, invoiceLimit, address]);
 
   // Compute stats
   const totalFunded = invoices.reduce((sum, inv) => sum + inv.fundedAmount, 0n);
@@ -65,6 +74,17 @@ export default function SMEDashboard() {
 
   const formatAddress = (addr: string) => {
     return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+  };
+
+  const handlePageChange = (page: number) => {
+    setInvoicePage(page);
+    setSelectedInvoice(null);
+  };
+
+  const handleLimitChange = (limit: number) => {
+    setInvoiceLimit(limit);
+    setInvoicePage(1);
+    setSelectedInvoice(null);
   };
 
   const formatEventDisplay = (event: (typeof events)[number]) => {
@@ -339,20 +359,20 @@ export default function SMEDashboard() {
                   invoices={invoices}
                   onSelectInvoice={(invoice) => setSelectedInvoice(invoice)}
                   activeId={selectedInvoice?.id}
-                  emptyState={
-                    <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
-                      <p className="text-slate-500 text-xs font-mono mb-6 leading-relaxed max-w-xs">
-                        Create your first invoice to get started
-                      </p>
-                      <button
-                        onClick={() => setShowCreateModal(true)}
-                        className="bg-primary hover:bg-primary-hover text-black font-bold uppercase tracking-wider text-xs rounded px-4 py-2.5 flex items-center gap-1.5 shadow-[0_0_15px_rgba(0,212,170,0.1)] transition-all"
-                      >
-                        <Plus className="w-4 h-4" />
-                        Create Invoice
-                      </button>
-                    </div>
-                  }
+                  emptyStateTitle="No invoices yet"
+                  emptyStateDescription="Create your first invoice to populate the dashboard and unlock the financing flow."
+                  emptyStateAction={{
+                    label: "Create Your First Invoice",
+                    onClick: () => setShowCreateModal(true),
+                  }}
+                  pagination={{
+                    page: invoicePage,
+                    limit: invoiceLimit,
+                    total,
+                    totalPages,
+                    onPageChange: handlePageChange,
+                    onLimitChange: handleLimitChange,
+                  }}
                 />
               </ErrorBoundary>
             )}

--- a/apps/web/app/invoice/[invoiceId]/InvoiceDetailClient.tsx
+++ b/apps/web/app/invoice/[invoiceId]/InvoiceDetailClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { PageLayout } from "@/components/shared/PageLayout";
 import { useInvoice, useInvoices } from "@/hooks/useInvoices";
@@ -15,6 +16,7 @@ import {
   Copy,
   Check,
   ArrowLeft,
+  ChevronRight,
   Lock,
   Users,
   Activity,
@@ -148,9 +150,9 @@ export default function InvoiceDetailClient({
           </p>
           <Button
             className="border border-border text-slate-300 font-mono text-xs uppercase px-4 py-2 hover:bg-slate-900"
-            onClick={() => router.push("/marketplace")}
+            onClick={() => router.push("/dashboard")}
           >
-            Return to Marketplace
+            Return to Dashboard
           </Button>
         </div>
       </PageLayout>
@@ -165,16 +167,24 @@ export default function InvoiceDetailClient({
   return (
     <PageLayout>
       <div className="space-y-6 py-4">
-        <div className="flex items-center gap-2">
-          <button
-            onClick={() => router.back()}
-            className="flex items-center gap-1.5 text-xs font-bold font-mono text-slate-500 hover:text-white uppercase transition-colors"
+        <div className="flex flex-wrap items-center gap-2 text-[10px] font-bold font-mono uppercase tracking-wider">
+          <Link
+            href="/dashboard"
+            className="flex items-center gap-1.5 text-slate-500 transition-colors hover:text-white"
           >
-            <ArrowLeft className="w-3.5 h-3.5" /> Back
-          </button>
-          <span className="text-slate-600 font-mono text-xs">/</span>
-          <span className="text-slate-400 font-mono text-xs font-bold">
-            Ledger Details
+            <ArrowLeft className="w-3.5 h-3.5" />
+            Dashboard
+          </Link>
+          <ChevronRight className="w-3.5 h-3.5 text-slate-700" />
+          <Link
+            href="/dashboard"
+            className="text-slate-500 transition-colors hover:text-white"
+          >
+            Invoices
+          </Link>
+          <ChevronRight className="w-3.5 h-3.5 text-slate-700" />
+          <span className="text-slate-400">
+            Invoice #{invoice.id.slice(0, 6)}...
           </span>
         </div>
 
@@ -354,7 +364,10 @@ export default function InvoiceDetailClient({
                 <div className="flex justify-between">
                   <span className="text-slate-500">Net Discount Fee:</span>
                   <span className="text-slate-300 font-bold">
-                    {formatAmount(invoice.faceValue - invoice.fundedAmount)}
+                    {formatAmount(
+                      BigInt(invoice.faceValue) - BigInt(invoice.fundedAmount),
+                      invoice.asset,
+                    )}
                   </span>
                 </div>
               </div>

--- a/apps/web/app/marketplace/page.tsx
+++ b/apps/web/app/marketplace/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useMemo } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import Link from "next/link";
 import { PageLayout } from "@/components/shared/PageLayout";
 import { InvoiceTable } from "@/components/invoice/InvoiceTable";
@@ -19,17 +19,26 @@ export default function Marketplace() {
   const { isVerified } = useProfile();
   const { stats, isStatsLoading } = usePool();
   const [statusFilter, setStatusFilter] = useState<string>("Listed");
+  const [invoicePage, setInvoicePage] = useState(1);
+  const [invoiceLimit, setInvoiceLimit] = useState(20);
 
   // Filter States
   const [minAmount, setMinAmount] = useState("");
   const [maxAmount, setMaxAmount] = useState("");
   const [maxDiscount, setMaxDiscount] = useState("500"); // 500 bps max
 
-  const { invoices, isLoading } = useInvoices({
+  const { invoices, isLoading, total, totalPages } = useInvoices({
     status: statusFilter === "ALL" ? undefined : statusFilter,
+    page: invoicePage,
+    limit: invoiceLimit,
   });
 
   const [selectedInvoice, setSelectedInvoice] = useState<Invoice | null>(null);
+
+  useEffect(() => {
+    setInvoicePage(1);
+    setSelectedInvoice(null);
+  }, [statusFilter, minAmount, maxAmount, maxDiscount]);
 
   // Filter and Sort Invoices
   const filteredAndSortedInvoices = useMemo(() => {
@@ -60,6 +69,17 @@ export default function Marketplace() {
       return 0;
     });
   }, [invoices, minAmount, maxAmount, maxDiscount]);
+
+  const handlePageChange = (page: number) => {
+    setInvoicePage(page);
+    setSelectedInvoice(null);
+  };
+
+  const handleLimitChange = (limit: number) => {
+    setInvoiceLimit(limit);
+    setInvoicePage(1);
+    setSelectedInvoice(null);
+  };
 
   // Calculate funded amount preview (face value - discount fee)
   const calculateFundingValue = (faceValue: bigint, discountBps: number) => {
@@ -215,25 +235,27 @@ export default function Marketplace() {
                 invoices={filteredAndSortedInvoices}
                 onSelectInvoice={(invoice) => setSelectedInvoice(invoice)}
                 activeId={selectedInvoice?.id}
-                emptyState={
-                  <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
-                    <p className="text-slate-500 text-xs font-mono mb-6 leading-relaxed max-w-xs">
-                      No invoices match your filters
-                    </p>
-                    <button
-                      onClick={() => {
-                        setStatusFilter("Listed");
-                        setMinAmount("");
-                        setMaxAmount("");
-                        setMaxDiscount("500");
-                        setSelectedInvoice(null);
-                      }}
-                      className="border border-border hover:border-primary/50 text-slate-300 hover:text-white font-bold text-xs uppercase tracking-wider rounded px-4 py-2.5 transition-all"
-                    >
-                      Reset Filters
-                    </button>
-                  </div>
-                }
+                emptyStateTitle="No invoices match your filters"
+                emptyStateDescription="Try broadening the amount range or resetting the filters to reveal more listed invoices."
+                emptyStateAction={{
+                  label: "Reset Filters",
+                  onClick: () => {
+                    setStatusFilter("Listed");
+                    setMinAmount("");
+                    setMaxAmount("");
+                    setMaxDiscount("500");
+                    setSelectedInvoice(null);
+                    setInvoicePage(1);
+                  },
+                }}
+                pagination={{
+                  page: invoicePage,
+                  limit: invoiceLimit,
+                  total,
+                  totalPages,
+                  onPageChange: handlePageChange,
+                  onLimitChange: handleLimitChange,
+                }}
               />
 
               {/* Mobile Cards view (hidden on desktop, but let's implement layout) */}

--- a/apps/web/components/invoice/InvoiceTable.test.tsx
+++ b/apps/web/components/invoice/InvoiceTable.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
 import { InvoiceTable } from "./InvoiceTable";
 
 const mockInvoices = [
@@ -29,8 +29,38 @@ describe("InvoiceTable", () => {
     expect(screen.getByText(/2,000.00 USDC/)).toBeInTheDocument();
   });
 
-  it("renders empty state when no invoices", () => {
+  it("renders a helpful empty state when no invoices", () => {
     render(<InvoiceTable invoices={[]} />);
-    expect(screen.getByText(/No invoices found/i)).toBeInTheDocument();
+    expect(screen.getByText(/No invoices yet/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Create Your First Invoice/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders pagination controls when provided", () => {
+    const onPageChange = vi.fn();
+    const onLimitChange = vi.fn();
+
+    render(
+      <InvoiceTable
+        invoices={mockInvoices as any}
+        pagination={{
+          page: 1,
+          limit: 20,
+          total: 40,
+          totalPages: 2,
+          onPageChange,
+          onLimitChange,
+        }}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "50" },
+    });
+    expect(onLimitChange).toHaveBeenCalledWith(50);
+
+    fireEvent.click(screen.getByRole("button", { name: /Next/i }));
+    expect(onPageChange).toHaveBeenCalledWith(2);
   });
 });

--- a/apps/web/components/invoice/InvoiceTable.tsx
+++ b/apps/web/components/invoice/InvoiceTable.tsx
@@ -1,15 +1,241 @@
 "use client";
 
-import React, { ReactNode } from "react";
-import { Invoice } from "@/types";
-import { InvoiceStatus } from "./InvoiceStatus";
+import React, {
+  ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import Link from "next/link";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { formatAmount } from "@/lib/assets";
+import { Invoice } from "@/types";
+import { Button } from "@/components/ui/button";
+import { InvoiceStatus } from "./InvoiceStatus";
+import {
+  ChevronLeft,
+  ChevronRight,
+  FilePlus2,
+  Inbox,
+  ReceiptText,
+} from "lucide-react";
+
+interface InvoicePaginationProps {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  onLimitChange: (limit: number) => void;
+  pageSizeOptions?: number[];
+}
+
+interface EmptyStateAction {
+  label: string;
+  onClick?: () => void;
+  href?: string;
+}
 
 interface InvoiceTableProps {
   invoices: Invoice[];
   onSelectInvoice?: (invoice: Invoice) => void;
   activeId?: string | null;
   emptyState?: ReactNode;
+  emptyStateTitle?: string;
+  emptyStateDescription?: string;
+  emptyStateAction?: EmptyStateAction;
+  pagination?: InvoicePaginationProps;
+}
+
+const DEFAULT_PAGE_SIZES = [10, 20, 50, 100];
+const ROW_HEIGHT = 72;
+
+function truncateAddr(addr: string) {
+  if (!addr) return "";
+  return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+}
+
+function clampPage(page: number, totalPages: number) {
+  return Math.min(Math.max(page, 1), Math.max(totalPages, 1));
+}
+
+function InvoiceEmptyState({
+  title = "No invoices yet",
+  description = "Create your first invoice to start populating the ledger.",
+  action = {
+    label: "Create Your First Invoice",
+    href: "/dashboard",
+  },
+}: {
+  title?: string;
+  description?: string;
+  action?: EmptyStateAction;
+}) {
+  const actionClasses =
+    "inline-flex items-center justify-center gap-1.5 rounded-md px-4 py-2.5 text-xs font-bold uppercase tracking-wider transition-all";
+
+  const actionNode = action?.href ? (
+    <Link
+      href={action.href}
+      className={`${actionClasses} bg-primary text-black hover:bg-primary-hover shadow-[0_0_15px_rgba(0,212,170,0.1)]`}
+    >
+      <FilePlus2 className="w-4 h-4" />
+      <span>{action.label}</span>
+    </Link>
+  ) : (
+    <Button
+      type="button"
+      onClick={action?.onClick}
+      className={`${actionClasses} bg-primary text-black hover:bg-primary-hover shadow-[0_0_15px_rgba(0,212,170,0.1)] border-0`}
+    >
+      <FilePlus2 className="w-4 h-4" />
+      <span>{action?.label ?? "Create Your First Invoice"}</span>
+    </Button>
+  );
+
+  return (
+    <div className="flex flex-col items-center justify-center px-6 py-16 text-center">
+      <div className="relative mb-6">
+        <div className="absolute inset-0 rounded-full bg-primary/10 blur-2xl" />
+        <div className="relative flex h-20 w-20 items-center justify-center rounded-full border border-primary/20 bg-[#0d131a] shadow-[0_0_30px_rgba(0,212,170,0.08)]">
+          <Inbox className="h-9 w-9 text-primary" />
+        </div>
+      </div>
+
+      <div className="max-w-md space-y-3">
+        <p className="text-[10px] font-bold uppercase tracking-[0.3em] text-slate-500">
+          Empty Ledger
+        </p>
+        <h3 className="text-sm font-bold uppercase tracking-wider text-white">
+          {title}
+        </h3>
+        <p className="text-xs leading-relaxed text-slate-500">{description}</p>
+      </div>
+
+      <div className="mt-8">{actionNode}</div>
+    </div>
+  );
+}
+
+function InvoicePagination({
+  page,
+  limit,
+  total,
+  totalPages,
+  onPageChange,
+  onLimitChange,
+  pageSizeOptions = DEFAULT_PAGE_SIZES,
+}: InvoicePaginationProps) {
+  const [pageInput, setPageInput] = useState(String(page));
+
+  useEffect(() => {
+    setPageInput(String(page));
+  }, [page]);
+
+  const startItem = total === 0 ? 0 : (page - 1) * limit + 1;
+  const endItem = total === 0 ? 0 : Math.min(page * limit, total);
+
+  const handleCommitPage = () => {
+    const parsed = Number.parseInt(pageInput, 10);
+    if (Number.isNaN(parsed)) {
+      setPageInput(String(page));
+      return;
+    }
+
+    onPageChange(clampPage(parsed, totalPages));
+  };
+
+  const options = useMemo(() => {
+    const base = new Set(pageSizeOptions);
+    base.add(limit);
+    return Array.from(base).sort((a, b) => a - b);
+  }, [limit, pageSizeOptions]);
+
+  return (
+    <div className="border-t border-border/60 bg-[#080c10]/55 px-4 py-4 sm:px-5">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-1.5">
+          <p className="text-[10px] font-bold uppercase tracking-wider text-slate-500">
+            Items per page
+          </p>
+          <select
+            value={limit}
+            onChange={(event) => onLimitChange(Number(event.target.value))}
+            className="min-w-[140px] rounded border border-border bg-[#0b1117] px-3 py-2 font-mono text-xs text-white outline-none transition-colors focus:border-primary"
+          >
+            {options.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-end lg:justify-end">
+          <label className="space-y-1.5">
+            <span className="block text-[10px] font-bold uppercase tracking-wider text-slate-500">
+              Jump to page
+            </span>
+            <input
+              type="number"
+              min={1}
+              max={totalPages}
+              value={pageInput}
+              onChange={(event) => setPageInput(event.target.value)}
+              onBlur={handleCommitPage}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  handleCommitPage();
+                }
+              }}
+              className="w-28 rounded border border-border bg-[#0b1117] px-3 py-2 font-mono text-xs text-white outline-none transition-colors focus:border-primary"
+            />
+          </label>
+
+          <div className="space-y-1.5">
+            <span className="block text-[10px] font-bold uppercase tracking-wider text-slate-500">
+              Navigation
+            </span>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="border-border bg-[#0b1117] text-slate-200 hover:bg-slate-900 hover:text-white"
+                onClick={() => onPageChange(clampPage(page - 1, totalPages))}
+                disabled={page <= 1}
+              >
+                <ChevronLeft className="mr-1.5 h-3.5 w-3.5" />
+                Prev
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="border-border bg-[#0b1117] text-slate-200 hover:bg-slate-900 hover:text-white"
+                onClick={() => onPageChange(clampPage(page + 1, totalPages))}
+                disabled={page >= totalPages}
+              >
+                Next
+                <ChevronRight className="ml-1.5 h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-col gap-1 border-t border-border/30 pt-3 text-[10px] font-mono uppercase tracking-wider text-slate-500 sm:flex-row sm:items-center sm:justify-between">
+        <span>
+          Showing {startItem}-{endItem} of {total} invoices
+        </span>
+        <span>
+          Page {page} of {totalPages}
+        </span>
+      </div>
+    </div>
+  );
 }
 
 export function InvoiceTable({
@@ -17,86 +243,145 @@ export function InvoiceTable({
   onSelectInvoice,
   activeId,
   emptyState,
+  emptyStateTitle,
+  emptyStateDescription,
+  emptyStateAction,
+  pagination,
 }: InvoiceTableProps) {
-  const truncateAddr = (addr: string) => {
-    if (!addr) return "";
-    return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
-  };
+  const parentRef = useRef<HTMLDivElement | null>(null);
+  const rowVirtualizer = useVirtualizer({
+    count: invoices.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 8,
+  });
 
-  if (invoices.length === 0 && emptyState) {
-    return (
-      <div className="bg-card border border-border rounded-lg overflow-hidden">
-        {emptyState}
-      </div>
-    );
-  }
+  useEffect(() => {
+    if (parentRef.current) {
+      parentRef.current.scrollTop = 0;
+    }
+  }, [pagination?.page, pagination?.limit, invoices.length]);
+
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const rowsToRender =
+    virtualRows.length > 0
+      ? virtualRows
+      : invoices.map((invoice, index) => ({
+          index,
+          start: index * ROW_HEIGHT,
+          key: invoice.id,
+        }));
+  const totalHeight =
+    virtualRows.length > 0
+      ? rowVirtualizer.getTotalSize()
+      : invoices.length * ROW_HEIGHT;
+
+  const emptyNode = emptyState ?? (
+    <InvoiceEmptyState
+      title={emptyStateTitle}
+      description={emptyStateDescription}
+      action={emptyStateAction}
+    />
+  );
 
   return (
-    <div className="bg-card border border-border rounded-lg overflow-hidden">
-      <div className="overflow-x-auto">
-        <table className="w-full text-left border-collapse">
-          <thead>
-            <tr className="border-b border-border bg-[#080c10]/40 text-[10px] font-bold font-mono text-slate-500 uppercase tracking-widest">
-              <th className="px-5 py-3.5">Invoice ID</th>
-              <th className="px-5 py-3.5">Buyer</th>
-              <th className="px-5 py-3.5">Face Value</th>
-              <th className="px-5 py-3.5">Discount</th>
-              <th className="px-5 py-3.5">Due Date</th>
-              <th className="px-5 py-3.5">Status</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-border/30 text-xs font-mono text-slate-300">
-            {invoices.length === 0 ? (
-              <tr>
-                <td
-                  colSpan={6}
-                  className="px-5 py-8 text-center text-slate-600 font-bold uppercase tracking-wider"
-                >
-                  No invoices found.
-                </td>
-              </tr>
-            ) : (
-              invoices.map((invoice) => {
-                const isActive = activeId === invoice.id;
-                return (
-                  <tr
-                    key={invoice.id}
-                    onClick={() => onSelectInvoice?.(invoice)}
-                    className={`transition-colors ${
-                      onSelectInvoice ? "cursor-pointer" : ""
-                    } ${
-                      isActive
-                        ? "bg-primary/5 text-primary"
-                        : "hover:bg-slate-900/50"
-                    }`}
-                  >
-                    <td className="px-5 py-3.5 text-primary font-bold">
-                      {truncateAddr(invoice.id)}
-                    </td>
-                    <td className="px-5 py-3.5 text-slate-400">
-                      {truncateAddr(invoice.buyer)}
-                    </td>
-                    <td className="px-5 py-3.5 text-white font-bold">
-                      {formatAmount(invoice.faceValue, invoice.asset)}
-                    </td>
-                    <td className="px-5 py-3.5 text-slate-300">
-                      {invoice.discountBps > 0
-                        ? `${(invoice.discountBps / 100).toFixed(2)}%`
-                        : "—"}
-                    </td>
-                    <td className="px-5 py-3.5 text-slate-400">
-                      {new Date(invoice.dueDate * 1000).toLocaleDateString()}
-                    </td>
-                    <td className="px-5 py-3.5">
-                      <InvoiceStatus status={invoice.status} />
-                    </td>
-                  </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
+    <div className="overflow-hidden rounded-lg border border-border bg-card">
+      <div className="border-b border-border/60 bg-[#080c10]/70 px-4 py-4 sm:px-5">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-0.5">
+            <p className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-[0.3em] text-slate-500">
+              <ReceiptText className="h-3.5 w-3.5 text-primary" />
+              Invoice Ledger
+            </p>
+            <p className="text-xs text-slate-500">
+              Browse, filter, and inspect tokenized trade obligations.
+            </p>
+          </div>
+
+          {pagination && invoices.length > 0 && (
+            <div className="text-[10px] font-mono uppercase tracking-wider text-slate-500">
+              {pagination.total} matching invoices
+            </div>
+          )}
+        </div>
       </div>
+
+      {invoices.length === 0 ? (
+        <div className="bg-[#080c10]/40">{emptyNode}</div>
+      ) : (
+        <>
+          <div className="overflow-x-auto">
+            <div className="min-w-[920px]">
+              <div className="grid grid-cols-[1.15fr_1.15fr_1fr_0.8fr_0.95fr_0.75fr] border-b border-border/60 bg-[#080c10]/80 px-5 py-3 text-[10px] font-bold uppercase tracking-widest text-slate-500">
+                <div>Invoice ID</div>
+                <div>Buyer</div>
+                <div>Face Value</div>
+                <div>Discount</div>
+                <div>Due Date</div>
+                <div>Status</div>
+              </div>
+
+              <div ref={parentRef} className="max-h-[65vh] overflow-auto">
+                <div
+                  className="relative w-full"
+                  style={{ height: `${totalHeight}px` }}
+                >
+                  {rowsToRender.map((virtualRow) => {
+                    const invoice = invoices[virtualRow.index];
+                    const isActive = activeId === invoice.id;
+
+                    return (
+                      <button
+                        key={invoice.id}
+                        type="button"
+                        onClick={() => onSelectInvoice?.(invoice)}
+                        disabled={!onSelectInvoice}
+                        aria-pressed={isActive}
+                        className={`absolute left-0 top-0 grid w-full grid-cols-[1.15fr_1.15fr_1fr_0.8fr_0.95fr_0.75fr] items-center border-b border-border/30 px-5 text-left font-mono text-xs transition-colors ${
+                          onSelectInvoice ? "cursor-pointer" : "cursor-default"
+                        } ${
+                          isActive
+                            ? "bg-primary/5 text-primary"
+                            : "hover:bg-slate-900/50"
+                        }`}
+                        style={{
+                          height: `${ROW_HEIGHT}px`,
+                          transform: `translateY(${virtualRow.start}px)`,
+                        }}
+                      >
+                        <div className="font-bold text-primary">
+                          {truncateAddr(invoice.id)}
+                        </div>
+                        <div className="text-slate-400">
+                          {truncateAddr(invoice.buyer)}
+                        </div>
+                        <div className="font-bold text-white">
+                          {formatAmount(invoice.faceValue, invoice.asset)}
+                        </div>
+                        <div className="text-slate-300">
+                          {invoice.discountBps > 0
+                            ? `${(invoice.discountBps / 100).toFixed(2)}%`
+                            : "—"}
+                        </div>
+                        <div className="text-slate-400">
+                          {new Date(invoice.dueDate * 1000).toLocaleDateString()}
+                        </div>
+                        <div className="flex justify-start">
+                          <InvoiceStatus status={invoice.status} />
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {pagination && (
+            <InvoicePagination {...pagination} />
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web/components/invoice/InvoiceTable.tsx
+++ b/apps/web/components/invoice/InvoiceTable.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import React, {
-  ReactNode,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { formatAmount } from "@/lib/assets";
@@ -364,7 +358,9 @@ export function InvoiceTable({
                             : "—"}
                         </div>
                         <div className="text-slate-400">
-                          {new Date(invoice.dueDate * 1000).toLocaleDateString()}
+                          {new Date(
+                            invoice.dueDate * 1000,
+                          ).toLocaleDateString()}
                         </div>
                         <div className="flex justify-start">
                           <InvoiceStatus status={invoice.status} />
@@ -377,9 +373,7 @@ export function InvoiceTable({
             </div>
           </div>
 
-          {pagination && (
-            <InvoicePagination {...pagination} />
-          )}
+          {pagination && <InvoicePagination {...pagination} />}
         </>
       )}
     </div>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "@stellar/freighter-api": "^2.0.0",
     "@stellar/stellar-sdk": "^13.3.0",
     "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-virtual": "^3.14.8",
     "@trusttrove/sdk": "workspace:*",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.101.0
         version: 5.101.2(react@18.3.1)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.8
+        version: 3.14.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@trusttrove/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk
@@ -710,6 +713,15 @@ packages:
     resolution: {integrity: sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-virtual@3.14.8':
+    resolution: {integrity: sha512-O39GJQpAYEJcIu3uN1//YtmhjSEOyw75vg9CKCatBDPiD5hKtZQoJHfferyrB/LdOD3UWaoMLWtdEjarwIwdDw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.6':
+    resolution: {integrity: sha512-h0/Ebo18CkOrChlQIhNtQkM5ySUnh/GumQ/D1st3hG2HWUPEF+ILUc2k29UtivCi/9G7w7G3/f7Xyd5cCFbKBw==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -3437,6 +3449,14 @@ snapshots:
       '@tanstack/query-core': 5.101.2
       react: 18.3.1
 
+  '@tanstack/react-virtual@3.14.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/virtual-core@3.17.6': {}
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -4259,8 +4279,8 @@ snapshots:
       '@typescript-eslint/parser': 8.62.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -4279,7 +4299,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4290,22 +4310,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.62.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4316,7 +4336,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
Implemented the invoice UX/perf pass.

- [InvoiceTable](/Users/marvellous/Desktop/TrusTrove-app/apps/web/components/invoice/InvoiceTable.tsx) now:
  - shows a proper empty state with illustration and CTA
  - supports customizable empty-state text/action
  - virtualizes invoice rows with `@tanstack/react-virtual`
  - adds `Items per page`, `Jump to page`, and prev/next controls

- [Dashboard](/Users/marvellous/Desktop/TrusTrove-app/apps/web/app/dashboard/page.tsx) now:
  - drives invoice pagination state into the table
  - resets selection on page/limit changes
  - shows a `Create Your First Invoice` CTA when empty

- [Marketplace](/Users/marvellous/Desktop/TrusTrove-app/apps/web/app/marketplace/page.tsx) now:
  - drives invoice pagination state into the table
  - resets page/selection when filters change
  - shows a `Reset Filters` CTA when no results match

- [Invoice detail](/Users/marvellous/Desktop/TrusTrove-app/apps/web/app/invoice/[invoiceId]/InvoiceDetailClient.tsx) now:
  - has breadcrumb-style navigation back to the dashboard invoice list
  - routes the “not found” state back to the dashboard as well

- [Invoice table tests](/Users/marvellous/Desktop/TrusTrove-app/apps/web/components/invoice/InvoiceTable.test.tsx) were updated for the new empty state and pagination UI.

- Added `@tanstack/react-virtual` to [apps/web/package.json](/Users/marvellous/Desktop/TrusTrove-app/apps/web/package.json) and updated [pnpm-lock.yaml](/Users/marvellous/Desktop/TrusTrove-app/pnpm-lock.yaml).

Verified:
- `./node_modules/.bin/vitest run components/invoice/InvoiceTable.test.tsx --config vitest.config.ts` passed
- `pnpm --filter web exec eslint components/invoice/InvoiceTable.tsx components/invoice/InvoiceTable.test.tsx app/dashboard/page.tsx app/marketplace/page.tsx 'app/invoice/[invoiceId]/InvoiceDetailClient.tsx'` passed
- `git diff --check` passed

Closes #195
Closes #198
Closes #199
Closes #200