### PR TITLE
fix(web): repair profile page duplicate submit block and TopStatusBar ticker issues

### DIFF
--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -486,34 +486,6 @@ export default function ProfilePage() {
                   {isRegistering ? "Signing..." : "Register Profile"}
                 </button>
               </div>
-
-              <div className="bg-[#080c10] border border-amber-500/20 p-3 rounded text-[10px] text-amber-500 leading-normal flex items-start gap-1.5">
-                <Lock className="w-3.5 h-3.5 shrink-0 mt-0.5" />
-                <span>
-                  Signing this registration requires Freighter authorization.
-                  You will submit a Soroban write transaction, which whitelists
-                  your wallet address and locks your business credentials.
-                </span>
-              </div>
-
-              {/* Buttons */}
-              <div className="flex gap-2 pt-2">
-                <button
-                  type="button"
-                  onClick={() => setShowRegModal(false)}
-                  className="flex-1 border border-border bg-transparent hover:bg-slate-900 text-slate-400 font-bold uppercase py-2.5 rounded"
-                  disabled={isRegistering}
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  className="flex-1 bg-primary hover:bg-primary-hover text-black font-bold uppercase py-2.5 rounded shadow-[0_0_15px_rgba(0,212,170,0.15)] flex items-center justify-center gap-1.5"
-                  disabled={isRegistering}
-                >
-                  {isRegistering ? "Signing..." : "Register Profile"}
-                </button>
-              </div>
             </form>
           </div>
         </ErrorBoundary>

--- a/apps/web/components/shared/TopStatusBar.tsx
+++ b/apps/web/components/shared/TopStatusBar.tsx
@@ -14,49 +14,6 @@ interface TickerItem {
   country: string;
 }
 
-const tickerItems: TickerItem[] = [
-  {
-    id: "1",
-    sme: "Lagos Textile Supplier",
-    amount: "34,500 USDC",
-    discount: "2.1%",
-    time: "3m ago",
-    country: "🇳🇬",
-  },
-  {
-    id: "2",
-    sme: "Nairobi Agri-Exporter",
-    amount: "18,200 USDC",
-    discount: "1.8%",
-    time: "8m ago",
-    country: "🇰🇪",
-  },
-  {
-    id: "3",
-    sme: "Accra Electronics",
-    amount: "52,000 USDC",
-    discount: "2.5%",
-    time: "12m ago",
-    country: "🇬🇭",
-  },
-  {
-    id: "4",
-    sme: "Mombasa Logistics Ltd",
-    amount: "27,800 USDC",
-    discount: "2.0%",
-    time: "22m ago",
-    country: "🇰🇪",
-  },
-  {
-    id: "5",
-    sme: "Dakar Fish Processing",
-    amount: "41,300 USDC",
-    discount: "2.3%",
-    time: "35m ago",
-    country: "🇸🇳",
-  },
-];
-
 export function TopStatusBar() {
   const { events: rawEvents, isLoading, error } = useRecentEvents(20);
   const isError = error !== null;
@@ -68,10 +25,12 @@ export function TopStatusBar() {
     // Extract amount from event data (assuming it's in USDC)
     let amount = "0 USDC";
     if (event.data && event.data.funded_amount) {
-      const amountInUSDC = Number(event.data.funded_amount) / 1000000; // Convert from stroops to USDC
+      const amountInUSDC =
+        Number(BigInt(event.data.funded_amount) / 10_000_000n); // Convert from stroops (7 decimals) to USDC
       amount = `${Math.round(amountInUSDC).toLocaleString()} USDC`;
     } else if (event.data && event.data.face_value) {
-      const amountInUSDC = Number(event.data.face_value) / 1000000; // Convert from stroops to USDC
+      const amountInUSDC =
+        Number(BigInt(event.data.face_value) / 10_000_000n); // Convert from stroops (7 decimals) to USDC
       amount = `${Math.round(amountInUSDC).toLocaleString()} USDC`;
     }
 

--- a/apps/web/components/shared/TopStatusBar.tsx
+++ b/apps/web/components/shared/TopStatusBar.tsx
@@ -25,12 +25,12 @@ export function TopStatusBar() {
     // Extract amount from event data (assuming it's in USDC)
     let amount = "0 USDC";
     if (event.data && event.data.funded_amount) {
-      const amountInUSDC =
-        Number(BigInt(event.data.funded_amount) / 10_000_000n); // Convert from stroops (7 decimals) to USDC
+      const amountInUSDC = Number(
+        BigInt(event.data.funded_amount) / 10_000_000n,
+      ); // Convert from stroops (7 decimals) to USDC
       amount = `${Math.round(amountInUSDC).toLocaleString()} USDC`;
     } else if (event.data && event.data.face_value) {
-      const amountInUSDC =
-        Number(BigInt(event.data.face_value) / 10_000_000n); // Convert from stroops (7 decimals) to USDC
+      const amountInUSDC = Number(BigInt(event.data.face_value) / 10_000_000n); // Convert from stroops (7 decimals) to USDC
       amount = `${Math.round(amountInUSDC).toLocaleString()} USDC`;
     }
 


### PR DESCRIPTION
Closes #269 - Removed the submit button and amber advisory panel that were rendered a second time below the registration form; only one of each now renders.

Closes #272 - Removed the dead module-level tickerItems array that was shadowed by local state, and fixed the stroop-to-USDC conversion to divide by 10,000,000 (7 decimals) instead of 1,000,000, which was rendering amounts at 10x actual value.

Closes #268 - Verified already resolved on main: useInvoices.ts and usePool.ts both already import and use useTokenAllowance correctly. No further changes needed.

Closes #265 - Verified already resolved on main: parseRawPoolStats (in both lib/transformers.ts and lib/api.ts) already populates totalShares from raw.total_shares. No further changes needed.
