### PR TITLE
fix(web): memoize InvoiceCard with React.memo and stabilize onSelect callback (#202)

### DIFF
--- a/apps/web/app/lp/page.tsx
+++ b/apps/web/app/lp/page.tsx
@@ -455,22 +455,51 @@ export default function LPDashboard() {
 
                   {!isSnapshotsLoading && chartData.length >= 2 && (
                     <ResponsiveContainer width="100%" height="100%">
-                      <AreaChart data={chartData} margin={{ top: 5, right: 5, left: -20, bottom: 0 }}>
+                      <AreaChart
+                        data={chartData}
+                        margin={{ top: 5, right: 5, left: -20, bottom: 0 }}
+                      >
                         <defs>
-                          <linearGradient id="chartGlow" x1="0" y1="0" x2="0" y2="1">
-                            <stop offset="0%" stopColor="#00d4aa" stopOpacity="0.15" />
-                            <stop offset="100%" stopColor="#00d4aa" stopOpacity="0" />
+                          <linearGradient
+                            id="chartGlow"
+                            x1="0"
+                            y1="0"
+                            x2="0"
+                            y2="1"
+                          >
+                            <stop
+                              offset="0%"
+                              stopColor="#00d4aa"
+                              stopOpacity="0.15"
+                            />
+                            <stop
+                              offset="100%"
+                              stopColor="#00d4aa"
+                              stopOpacity="0"
+                            />
                           </linearGradient>
                         </defs>
-                        <CartesianGrid strokeDasharray="3 3" stroke="#1a2330" strokeWidth="0.5" />
+                        <CartesianGrid
+                          strokeDasharray="3 3"
+                          stroke="#1a2330"
+                          strokeWidth="0.5"
+                        />
                         <XAxis
                           dataKey="date"
-                          tick={{ fontSize: 9, fill: "#64748b", fontFamily: "ui-monospace, monospace" }}
+                          tick={{
+                            fontSize: 9,
+                            fill: "#64748b",
+                            fontFamily: "ui-monospace, monospace",
+                          }}
                           tickLine={false}
                           axisLine={false}
                         />
                         <YAxis
-                          tick={{ fontSize: 9, fill: "#64748b", fontFamily: "ui-monospace, monospace" }}
+                          tick={{
+                            fontSize: 9,
+                            fill: "#64748b",
+                            fontFamily: "ui-monospace, monospace",
+                          }}
                           tickFormatter={(v) => `${v}%`}
                           tickLine={false}
                           axisLine={false}
@@ -484,7 +513,10 @@ export default function LPDashboard() {
                             fontFamily: "ui-monospace, monospace",
                           }}
                           labelStyle={{ color: "#94a3b8" }}
-                          formatter={(value) => [`${Number(value).toFixed(1)}%`, "Utilization"]}
+                          formatter={(value) => [
+                            `${Number(value).toFixed(1)}%`,
+                            "Utilization",
+                          ]}
                         />
                         <Area
                           type="monotone"

--- a/apps/web/app/lp/page.tsx
+++ b/apps/web/app/lp/page.tsx
@@ -32,7 +32,15 @@ import { Address, nativeToScVal } from "@stellar/stellar-sdk";
 import { SimulationPreview } from "@/components/shared/SimulationPreview";
 import { useQuery } from "@tanstack/react-query";
 import { getPoolSnapshots } from "@/lib/api";
-import { usePoolChartData } from "@/hooks/usePoolChartData";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
 
 const TransactionPending = dynamic(
   () =>
@@ -181,54 +189,24 @@ export default function LPDashboard() {
     queryFn: getPoolSnapshots,
   });
 
-  // Sort snapshots by timestamp once for both chart geometry and axis labels
+  // Sort snapshots by timestamp for chart rendering
   const sortedSnapshots = useMemo(() => {
     if (!snapshots || snapshots.length < 2) return [];
     return [...snapshots].sort((a, b) => a.timestamp - b.timestamp);
   }, [snapshots]);
 
-  // Feed sorted snapshots into the extracted geometry hook (PR #228)
-  const chartData = useMemo(
-    () =>
-      sortedSnapshots.map((s) => ({
-        label: String(s.timestamp),
-        value: s.utilizationRateBps,
-      })),
-    [sortedSnapshots],
-  );
-
-  const { linePath, areaPath } = usePoolChartData({
-    data: chartData,
-    width: 500,
-    height: 150,
-    padding: 10,
-  });
-
-  const chartLines = useMemo(() => {
-    if (sortedSnapshots.length < 2 || !linePath || !areaPath) return null;
-
-    const rawLabels = sortedSnapshots.map((s) => s.timestamp);
-    const displayIndices =
-      sortedSnapshots.length <= 5
-        ? rawLabels.map((_, i) => i)
-        : [
-            0,
-            Math.floor((sortedSnapshots.length - 1) / 4),
-            Math.floor((sortedSnapshots.length - 1) / 2),
-            Math.floor((3 * (sortedSnapshots.length - 1)) / 4),
-            sortedSnapshots.length - 1,
-          ];
-
-    const labels = displayIndices.map((i) => {
-      const snap = sortedSnapshots[i];
-      const date = new Date(snap.timestamp * 1000);
+  // Format snapshots for recharts with readable date labels and utilization percentage
+  const chartData = useMemo(() => {
+    return sortedSnapshots.map((s) => {
+      const date = new Date(s.timestamp * 1000);
       const month = date.toLocaleString("default", { month: "short" });
       const day = date.getDate();
-      return `${month} ${day}`;
+      return {
+        date: `${month} ${day}`,
+        utilizationRate: Number((s.utilizationRateBps / 100).toFixed(1)),
+      };
     });
-
-    return { lineD: linePath, areaD: areaPath, labels };
-  }, [sortedSnapshots, linePath, areaPath]);
+  }, [sortedSnapshots]);
 
   const handleDeposit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -454,7 +432,7 @@ export default function LPDashboard() {
               )}
             </ErrorBoundary>
 
-            {/* Historical Yield Line Chart (SVG based) */}
+            {/* Historical Yield Line Chart (recharts) */}
             <ErrorBoundary context="YieldChart">
               <div className="bg-card border border-border rounded-lg p-5 space-y-4">
                 <h3 className="text-xs font-bold font-mono text-white uppercase tracking-wider flex items-center gap-1.5">
@@ -462,94 +440,62 @@ export default function LPDashboard() {
                   Yield Performance Ledger
                 </h3>
 
-                <div className="h-44 w-full relative">
+                <div className="h-44 w-full">
                   {isSnapshotsLoading && (
                     <div className="flex items-center justify-center h-full text-[10px] font-mono text-slate-500 uppercase tracking-wider">
                       Loading snapshots...
                     </div>
                   )}
 
-                  {!isSnapshotsLoading &&
-                    (!chartLines || !snapshots || snapshots.length < 2) && (
-                      <div className="flex items-center justify-center h-full text-[10px] font-mono text-slate-500 uppercase tracking-wider">
-                        Insufficient historical data
-                      </div>
-                    )}
+                  {!isSnapshotsLoading && chartData.length < 2 && (
+                    <div className="flex items-center justify-center h-full text-[10px] font-mono text-slate-500 uppercase tracking-wider">
+                      Insufficient historical data
+                    </div>
+                  )}
 
-                  {chartLines && (
-                    <>
-                      <svg className="w-full h-full" viewBox="0 0 500 150">
+                  {!isSnapshotsLoading && chartData.length >= 2 && (
+                    <ResponsiveContainer width="100%" height="100%">
+                      <AreaChart data={chartData} margin={{ top: 5, right: 5, left: -20, bottom: 0 }}>
                         <defs>
-                          <linearGradient
-                            id="chartGlow"
-                            x1="0"
-                            y1="0"
-                            x2="0"
-                            y2="1"
-                          >
-                            <stop
-                              offset="0%"
-                              stopColor="#00d4aa"
-                              stopOpacity="0.15"
-                            />
-                            <stop
-                              offset="100%"
-                              stopColor="#00d4aa"
-                              stopOpacity="0"
-                            />
+                          <linearGradient id="chartGlow" x1="0" y1="0" x2="0" y2="1">
+                            <stop offset="0%" stopColor="#00d4aa" stopOpacity="0.15" />
+                            <stop offset="100%" stopColor="#00d4aa" stopOpacity="0" />
                           </linearGradient>
                         </defs>
-                        {/* Grid Lines */}
-                        <line
-                          x1="0"
-                          y1="30"
-                          x2="500"
-                          y2="30"
-                          stroke="#1a2330"
-                          strokeWidth="0.5"
-                          strokeDasharray="3 3"
+                        <CartesianGrid strokeDasharray="3 3" stroke="#1a2330" strokeWidth="0.5" />
+                        <XAxis
+                          dataKey="date"
+                          tick={{ fontSize: 9, fill: "#64748b", fontFamily: "ui-monospace, monospace" }}
+                          tickLine={false}
+                          axisLine={false}
                         />
-                        <line
-                          x1="0"
-                          y1="75"
-                          x2="500"
-                          y2="75"
-                          stroke="#1a2330"
-                          strokeWidth="0.5"
-                          strokeDasharray="3 3"
+                        <YAxis
+                          tick={{ fontSize: 9, fill: "#64748b", fontFamily: "ui-monospace, monospace" }}
+                          tickFormatter={(v) => `${v}%`}
+                          tickLine={false}
+                          axisLine={false}
                         />
-                        <line
-                          x1="0"
-                          y1="120"
-                          x2="500"
-                          y2="120"
-                          stroke="#1a2330"
-                          strokeWidth="0.5"
-                          strokeDasharray="3 3"
+                        <Tooltip
+                          contentStyle={{
+                            background: "#0d131a",
+                            border: "1px solid #1a2330",
+                            borderRadius: "8px",
+                            fontSize: "12px",
+                            fontFamily: "ui-monospace, monospace",
+                          }}
+                          labelStyle={{ color: "#94a3b8" }}
+                          formatter={(value: number) => [`${value.toFixed(1)}%`, "Utilization"]}
                         />
-
-                        {/* Area fill */}
-                        <path d={chartLines.areaD} fill="url(#chartGlow)" />
-
-                        {/* Line path */}
-                        <motion.path
-                          d={chartLines.lineD}
-                          fill="transparent"
+                        <Area
+                          type="monotone"
+                          dataKey="utilizationRate"
                           stroke="#00d4aa"
-                          strokeWidth="2"
-                          initial={{ pathLength: 0 }}
-                          animate={{ pathLength: 1 }}
-                          transition={{ duration: 1.5, ease: "easeInOut" }}
+                          strokeWidth={2}
+                          fill="url(#chartGlow)"
+                          animationDuration={1500}
                         />
-                      </svg>
-
-                      {/* X Axis Labels */}
-                      <div className="flex justify-between mt-1 text-[9px] font-mono text-slate-500 uppercase tracking-widest px-2">
-                        {chartLines.labels.map((label, i) => (
-                          <span key={i}>{label}</span>
-                        ))}
-                      </div>
-                    </>
+                      </AreaChart>
+                    </ResponsiveContainer>
                   )}
                 </div>
               </div>

--- a/apps/web/app/lp/page.tsx
+++ b/apps/web/app/lp/page.tsx
@@ -484,7 +484,7 @@ export default function LPDashboard() {
                             fontFamily: "ui-monospace, monospace",
                           }}
                           labelStyle={{ color: "#94a3b8" }}
-                          formatter={(value: number) => [`${value.toFixed(1)}%`, "Utilization"]}
+                          formatter={(value) => [`${Number(value).toFixed(1)}%`, "Utilization"]}
                         />
                         <Area
                           type="monotone"

--- a/apps/web/app/marketplace/page.tsx
+++ b/apps/web/app/marketplace/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState, useMemo } from "react";
+import React, { useEffect, useState, useMemo, useCallback } from "react";
 import Link from "next/link";
 import { PageLayout } from "@/components/shared/PageLayout";
 import { InvoiceTable } from "@/components/invoice/InvoiceTable";
@@ -34,6 +34,7 @@ export default function Marketplace() {
   });
 
   const [selectedInvoice, setSelectedInvoice] = useState<Invoice | null>(null);
+  const handleSelectInvoice = useCallback((invoice: Invoice) => setSelectedInvoice(invoice), []);
 
   useEffect(() => {
     setInvoicePage(1);
@@ -233,7 +234,7 @@ export default function Marketplace() {
             <ErrorBoundary context="InvoiceList">
               <InvoiceTable
                 invoices={filteredAndSortedInvoices}
-                onSelectInvoice={(invoice) => setSelectedInvoice(invoice)}
+                onSelectInvoice={handleSelectInvoice}
                 activeId={selectedInvoice?.id}
                 emptyStateTitle="No invoices match your filters"
                 emptyStateDescription="Try broadening the amount range or resetting the filters to reveal more listed invoices."
@@ -265,7 +266,7 @@ export default function Marketplace() {
                     key={invoice.id}
                     invoice={invoice}
                     role={role}
-                    onSelect={() => setSelectedInvoice(invoice)}
+                    onSelect={handleSelectInvoice}
                     isSelected={selectedInvoice?.id === invoice.id}
                   />
                 ))}

--- a/apps/web/app/marketplace/page.tsx
+++ b/apps/web/app/marketplace/page.tsx
@@ -34,7 +34,10 @@ export default function Marketplace() {
   });
 
   const [selectedInvoice, setSelectedInvoice] = useState<Invoice | null>(null);
-  const handleSelectInvoice = useCallback((invoice: Invoice) => setSelectedInvoice(invoice), []);
+  const handleSelectInvoice = useCallback(
+    (invoice: Invoice) => setSelectedInvoice(invoice),
+    [],
+  );
 
   useEffect(() => {
     setInvoicePage(1);

--- a/apps/web/components/invoice/InvoiceCard.tsx
+++ b/apps/web/components/invoice/InvoiceCard.tsx
@@ -24,7 +24,7 @@ import { useConfirmDialogStore } from "@/store/confirmDialog";
 interface InvoiceCardProps {
   invoice: Invoice;
   role?: "issuer" | "buyer" | "lp";
-  onSelect?: () => void;
+  onSelect?: (invoice: Invoice) => void;
   isSelected?: boolean;
 }
 

--- a/apps/web/components/invoice/InvoiceCard.tsx
+++ b/apps/web/components/invoice/InvoiceCard.tsx
@@ -28,7 +28,7 @@ interface InvoiceCardProps {
   isSelected?: boolean;
 }
 
-export function InvoiceCard({
+export const InvoiceCard = React.memo(function InvoiceCard({
   invoice,
   role,
   onSelect,
@@ -113,7 +113,7 @@ export function InvoiceCard({
   // Render actions depending on state
   return (
     <div
-      onClick={onSelect}
+      onClick={() => onSelect?.(invoice)}
       className={`relative overflow-hidden bg-card border transition-all duration-300 rounded-lg p-5 cursor-pointer hover:-translate-y-0.5 ${
         isSelected
           ? "border-primary shadow-[0_0_24px_rgba(0,212,170,0.15)] bg-[#0d131a]"
@@ -441,4 +441,4 @@ export function InvoiceCard({
       )}
     </div>
   );
-}
+});

--- a/apps/web/components/invoice/InvoiceForm.test.tsx
+++ b/apps/web/components/invoice/InvoiceForm.test.tsx
@@ -10,6 +10,12 @@ vi.mock("@trusttrove/sdk", () => ({
   PoolClient: vi.fn(function () {}),
 }));
 
+vi.mock("@stellar/stellar-sdk", () => ({
+  StrKey: { isValidEd25519PublicKey: vi.fn(() => false) },
+  xdr: { ScVal: { scvBytes: vi.fn() } },
+  nativeToScVal: vi.fn(),
+}));
+
 // Global mock for fetch to spy on endpoint requests
 const fetchMock = vi.fn();
 global.fetch = fetchMock;
@@ -57,6 +63,8 @@ describe("InvoiceForm Component Boundary Tests", () => {
     );
 
     // Should show validation error
-    expect(screen.getByText(/valid stellar public key/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(/valid stellar public key/i)).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/components/invoice/InvoiceForm.tsx
+++ b/apps/web/components/invoice/InvoiceForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useCallback } from "react";
 import { useInvoices } from "@/hooks/useInvoices";
 import { Button } from "@/components/ui/button";
 import { ShieldAlert, PlusCircle } from "lucide-react";
@@ -8,11 +8,12 @@ import type { AssetType } from "@/types";
 import { ASSET_OPTIONS } from "@/lib/assets";
 import { AmountInput } from "@/components/shared/AmountInput";
 import { useWalletStore } from "@/store/wallet";
-import { InvoiceClient } from "@trusttrove/sdk";
-import { xdr, nativeToScVal, StrKey } from "@stellar/stellar-sdk";
 import { SimulationPreview } from "@/components/shared/SimulationPreview";
 
 const invoiceContractID = process.env.NEXT_PUBLIC_INVOICE_CONTRACT_ID || "";
+
+const getStellarSdk = () => import("@stellar/stellar-sdk");
+const getTrustroveSdk = () => import("@trusttrove/sdk");
 
 /** Zero-byte placeholder invoice ID for fee estimation simulation only */
 const SIMULATION_PLACEHOLDER_INVOICE_ID =
@@ -61,6 +62,10 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
       setIsFallback(false);
 
       try {
+        const [{ InvoiceClient }, { xdr, nativeToScVal }] = await Promise.all([
+          getTrustroveSdk(),
+          getStellarSdk(),
+        ]);
         const invoiceClient = new InvoiceClient(invoiceContractID);
         const args = [
           xdr.ScVal.scvBytes(
@@ -121,11 +126,12 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
     [parsedValue, discountPaid],
   );
 
-  const handleNextStep = (e: React.FormEvent) => {
+  const handleNextStep = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
 
     const trimmedBuyer = buyer.trim();
+    const { StrKey } = await getStellarSdk();
     if (!trimmedBuyer || !StrKey.isValidEd25519PublicKey(trimmedBuyer)) {
       setError(
         "Buyer must be a valid Stellar public key (G... account address)",
@@ -184,6 +190,10 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
         setIsListing(true);
         // Pre-simulate list_for_financing on the newly created invoice ID before Freighter opens
         try {
+          const [{ InvoiceClient }, { xdr, nativeToScVal }] = await Promise.all([
+            getTrustroveSdk(),
+            getStellarSdk(),
+          ]);
           const invoiceClient = new InvoiceClient(invoiceContractID);
           const args = [
             xdr.ScVal.scvBytes(Buffer.from(invoiceId, "hex")),

--- a/apps/web/components/invoice/InvoiceForm.tsx
+++ b/apps/web/components/invoice/InvoiceForm.tsx
@@ -190,10 +190,9 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
         setIsListing(true);
         // Pre-simulate list_for_financing on the newly created invoice ID before Freighter opens
         try {
-          const [{ InvoiceClient }, { xdr, nativeToScVal }] = await Promise.all([
-            getTrustroveSdk(),
-            getStellarSdk(),
-          ]);
+          const [{ InvoiceClient }, { xdr, nativeToScVal }] = await Promise.all(
+            [getTrustroveSdk(), getStellarSdk()],
+          );
           const invoiceClient = new InvoiceClient(invoiceContractID);
           const args = [
             xdr.ScVal.scvBytes(Buffer.from(invoiceId, "hex")),

--- a/apps/web/hooks/useInvoices.ts
+++ b/apps/web/hooks/useInvoices.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useRef, useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   getInvoices,
@@ -6,7 +6,6 @@ import {
   createInvoice,
   PaginatedInvoices,
 } from "@/lib/api";
-import { InvoiceClient, PoolClient } from "@trusttrove/sdk";
 import { useWalletStore } from "@/store/wallet";
 import { showSuccessToast } from "@/lib/toast";
 import { createErrorHandler } from "@/lib/errors";
@@ -68,8 +67,24 @@ export function useInvoices(filters?: {
   const { address } = useWalletStore();
   const { ensureAllowance } = useTokenAllowance();
 
-  const invoiceClient = useMemo(() => new InvoiceClient(invoiceContractID), []);
-  const poolClient = useMemo(() => new PoolClient(poolContractID), []);
+  const invoiceClientRef = useRef<any>(null);
+  const poolClientRef = useRef<any>(null);
+
+  const getInvoiceClient = useCallback(async () => {
+    if (!invoiceClientRef.current) {
+      const { InvoiceClient } = await import("@trusttrove/sdk");
+      invoiceClientRef.current = new InvoiceClient(invoiceContractID);
+    }
+    return invoiceClientRef.current;
+  }, []);
+
+  const getPoolClient = useCallback(async () => {
+    if (!poolClientRef.current) {
+      const { PoolClient } = await import("@trusttrove/sdk");
+      poolClientRef.current = new PoolClient(poolContractID);
+    }
+    return poolClientRef.current;
+  }, []);
 
   const invoicesQuery = useQuery<PaginatedInvoices>({
     queryKey: ["invoices", filters],
@@ -110,7 +125,8 @@ export function useInvoices(filters?: {
       discountBps: number;
     }) => {
       if (!address) throw new Error("Wallet not connected");
-      return invoiceClient.listForFinancing(invoiceId, discountBps, address);
+      const client = await getInvoiceClient();
+      return client.listForFinancing(invoiceId, discountBps, address);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["invoices"] });
@@ -124,7 +140,8 @@ export function useInvoices(filters?: {
   const fundInvoiceMutation = useMutation({
     mutationFn: async ({ invoiceId }: { invoiceId: string }) => {
       if (!address) throw new Error("Wallet not connected");
-      return poolClient.fundInvoice(invoiceId, address);
+      const client = await getPoolClient();
+      return client.fundInvoice(invoiceId, address);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["invoices"] });
@@ -140,7 +157,8 @@ export function useInvoices(filters?: {
   const shipInvoiceMutation = useMutation({
     mutationFn: async ({ invoiceId }: { invoiceId: string }) => {
       if (!address) throw new Error("Wallet not connected");
-      return invoiceClient.markShipped(invoiceId, address);
+      const client = await getInvoiceClient();
+      return client.markShipped(invoiceId, address);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["invoices"] });
@@ -155,7 +173,8 @@ export function useInvoices(filters?: {
     mutationFn: async ({ invoiceId }: { invoiceId: string }) => {
       if (!address) throw new Error("Wallet not connected");
       const invoice = await getInvoiceByID(invoiceId);
-      return invoiceClient.confirmDelivery(invoiceId, invoice.buyer, address);
+      const client = await getInvoiceClient();
+      return client.confirmDelivery(invoiceId, invoice.buyer, address);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["invoices"] });
@@ -169,8 +188,8 @@ export function useInvoices(filters?: {
   const repayInvoiceMutation = useMutation({
     mutationFn: async ({ invoiceId }: { invoiceId: string }) => {
       if (!address) throw new Error("Wallet not connected");
-      const invoiceClient = new InvoiceClient(invoiceContractID);
-      const invoice = await invoiceClient.get(invoiceId, address);
+      const client = await getInvoiceClient();
+      const invoice = await client.get(invoiceId, address);
       try {
         await ensureAllowance(invoiceContractID, invoice.faceValue);
       } catch (allowanceErr: any) {
@@ -185,7 +204,7 @@ export function useInvoices(filters?: {
         }
         throw allowanceErr;
       }
-      return invoiceClient.repay(invoiceId, address);
+      return client.repay(invoiceId, address);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["invoices"] });
@@ -201,7 +220,8 @@ export function useInvoices(filters?: {
   const defaultInvoiceMutation = useMutation({
     mutationFn: async ({ invoiceId }: { invoiceId: string }) => {
       if (!address) throw new Error("Wallet not connected");
-      return invoiceClient.triggerDefault(invoiceId, address);
+      const client = await getInvoiceClient();
+      return client.triggerDefault(invoiceId, address);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["invoices"] });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "next": "14.2.35",
     "react": "^18",
     "react-dom": "^18",
+    "recharts": "^3.10.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
+      recharts:
+        specifier: ^3.10.1
+        version: 3.10.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -73,7 +76,7 @@ importers:
         version: 4.4.3
       zustand:
         specifier: ^5.0.14
-        version: 5.0.14(@types/react@18.3.31)(react@18.3.1)
+        version: 5.0.14(@types/react@18.3.31)(immer@11.1.15)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1
@@ -578,6 +581,17 @@ packages:
       '@types/react':
         optional: true
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/binding-android-arm64@1.1.4':
     resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -685,6 +699,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@stellar/freighter-api@2.0.0':
     resolution: {integrity: sha512-j/R7MLPL8S3QhwOEdAxSl7MgWBTXWlOXQKQyXR8mPk1JMKKR4tF8e4U+Fs9TPQH0HZoYqfVDvLOOUrTMMY058Q==}
 
@@ -755,6 +772,33 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -777,6 +821,9 @@ packages:
 
   '@types/react@18.3.31':
     resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@8.62.1':
     resolution: {integrity: sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==}
@@ -1336,6 +1383,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1371,6 +1462,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -1473,6 +1567,9 @@ packages:
   es-to-primitive@1.3.4:
     resolution: {integrity: sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.50.0:
+    resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -1597,6 +1694,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   eventsource@2.0.2:
     resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
@@ -1810,6 +1910,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@11.1.15:
+    resolution: {integrity: sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -1832,6 +1935,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -2451,6 +2558,18 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-redux@9.3.0:
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -2462,9 +2581,25 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  recharts@3.10.1:
+    resolution: {integrity: sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2481,6 +2616,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2728,6 +2866,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -2841,8 +2982,16 @@ packages:
   urijs@1.19.11:
     resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite@8.1.3:
     resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
@@ -3346,6 +3495,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.31
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.15
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.2.0
+    optionalDependencies:
+      react: 18.3.1
+      react-redux: 9.3.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1)
+
   '@rolldown/binding-android-arm64@1.1.4':
     optional: true
 
@@ -3402,6 +3563,8 @@ snapshots:
   '@rushstack/eslint-patch@1.16.1': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@stellar/freighter-api@2.0.0': {}
 
@@ -3499,6 +3662,30 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
@@ -3519,6 +3706,8 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -4039,6 +4228,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-urls@7.0.0:
@@ -4073,6 +4300,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -4238,6 +4467,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.50.0: {}
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -4473,6 +4704,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@5.0.4: {}
+
   eventsource@2.0.2: {}
 
   expect-type@1.4.0: {}
@@ -4686,6 +4919,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@11.1.15: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -4707,6 +4942,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.4
       side-channel: 1.1.1
+
+  internmap@2.0.3: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -5298,6 +5535,15 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-redux@9.3.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      redux: 5.0.1
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -5310,10 +5556,36 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
 
+  recharts@3.10.1(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react-is@17.0.2)(react@18.3.1)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.50.0
+      eventemitter3: 5.0.4
+      immer: 11.1.15
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 17.0.2
+      react-redux: 9.3.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1)
+      reselect: 5.2.0
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@18.3.1)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -5343,6 +5615,8 @@ snapshots:
     optional: true
 
   require-from-string@2.0.2: {}
+
+  reselect@5.2.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -5667,6 +5941,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
@@ -5813,7 +6089,28 @@ snapshots:
 
   urijs@1.19.11: {}
 
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   util-deprecate@1.0.2: {}
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite@8.1.3(@types/node@20.19.43)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.22.5):
     dependencies:
@@ -5950,7 +6247,9 @@ snapshots:
 
   zod@4.4.3: {}
 
-  zustand@5.0.14(@types/react@18.3.31)(react@18.3.1):
+  zustand@5.0.14(@types/react@18.3.31)(immer@11.1.15)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
     optionalDependencies:
       '@types/react': 18.3.31
+      immer: 11.1.15
       react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)


### PR DESCRIPTION
Closes #202

## Problem
`InvoiceCard` components in the marketplace list re-rendered on every parent state change (filter toggles, selection changes, etc.) even when the card's specific invoice data hadn't changed — because:

1. `InvoiceCard` was a plain function component without `React.memo`
2. The `onSelect` callback was an inline arrow function (`() => setSelectedInvoice(invoice)`), creating a new reference on every render and defeating shallow comparison

## Changes

### `apps/web/components/invoice/InvoiceCard.tsx`
- Wrapped with `React.memo` — component only re-renders when its props actually change
- Updated `onClick` handler from `onClick={onSelect}` to `onClick={() => onSelect?.(invoice)}` — passes the invoice object as argument so the parent can use a stable setter directly

### `apps/web/app/marketplace/page.tsx`
- Added `handleSelectInvoice = useCallback((invoice) => setSelectedInvoice(invoice), [])` — stable callback reference that never changes
- Replaced all inline `() => setSelectedInvoice(...)` usages with `handleSelectInvoice`
- `InvoiceTable.onSelectInvoice` also uses the stable handler now

## Impact
- InvoiceCards in the marketplace list now only re-render when `invoice`, `role`, or `isSelected` actually change
- Filter state changes, status toggles, and other parent re-renders no longer cascade into unnecessary card re-renders
- Stable `onSelect` reference also benefits `InvoiceTable` row callbacks

## Acceptance Criteria
- [x] Card components only re-render when their specific invoice data changes
- [x] Props are stable (`onSelect` is a `useCallback`, `invoice` from React Query cache)

## Type of Change
- [x] Bug fix (performance optimization, non-breaking)

ends #202