### PR TITLE
docs(repo): fix placeholder, typecheck ref, sample output, and gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,3 @@ pnpm-debug.log*
 .DS_Store
 Thumbs.db
 .neon
-create_pr.ps1
-build_output.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ Thank you for your interest in contributing to TrusTrove! To maintain code quali
 Before opening or requesting review of a pull request, confirm the following:
 
 - [ ] Code compiles without errors (`pnpm build` / `go build -v .`)
+- [ ] TypeScript type-checking passes with no errors (`pnpm typecheck`)
 - [ ] Linting passes (`pnpm --filter web lint` / `go vet ./...`)
 - [ ] All existing and new tests pass (`pnpm test` / `go test ./...`)
 - [ ] No `TODO`, stub, or placeholder code is present
@@ -65,7 +66,17 @@ cd indexer
 go build -v .
 ```
 
-### 2. Linting & Code Quality
+### 2. Type-Checking
+
+Run the TypeScript compiler in check-only mode across all packages:
+
+```bash
+pnpm typecheck
+```
+
+This runs `tsc --noEmit` recursively over every TypeScript package in the monorepo and reports type errors without emitting any output files. Fix all errors before opening a PR.
+
+### 3. Linting & Code Quality
 
 Run linters on edited workspace directories:
 
@@ -78,12 +89,14 @@ cd indexer
 go vet ./...
 ```
 
-### 3. Testing
+### 4. Testing
 
-Ensure all tests pass before submitting code:
+The test suite is split across two runtimes. Both must pass before opening a PR.
+
+**TypeScript tests** (SDK + web, run from the repo root):
 
 ```bash
-# Run all workspace tests
+# Run all TypeScript workspace tests
 pnpm test
 
 # Run frontend tests only
@@ -91,10 +104,9 @@ pnpm --filter web test
 
 # Run SDK tests only
 pnpm --filter @trusttrove/sdk test
-
-# Run Go indexer tests
-cd indexer && go test ./...
 ```
+
+> **Note:** `pnpm test` only covers the TypeScript packages (`@trusttrove/sdk` and `web`). It does **not** run the Go indexer tests.
 
 Example output (all passing):
 
@@ -104,6 +116,17 @@ Example output (all passing):
 Test Suites: 12 passed, 12 total
 Tests:       47 passed, 47 total
 Time:        2.34 s
+```
+
+**Go tests** (indexer, run from the `indexer/` directory):
+
+```bash
+cd indexer && go test ./...
+```
+
+Example output (all passing):
+
+```text
 ok  	github.com/trusttrove/indexer	0.876s
 ```
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -2,7 +2,25 @@
 
 ## Register
 
-product
+Registration is the one-time on-chain step that gates all protocol activity. No address can create an invoice, fund a pool, or repay a trade obligation unless both the issuer (SME) and the buyer are registered in the registry contract.
+
+**SME (Issuer) flow:**
+
+1. Install the [Freighter](https://freighter.app) browser extension and switch it to Testnet.
+2. Visit the app and click **Connect Wallet** — Freighter handles the SEP-10 authentication challenge automatically.
+3. On first connection the app detects an unverified address and surfaces an onboarding prompt. Click **Register as SME**, fill in company details, and sign the `register_issuer` transaction with Freighter. This is a one-time action; the registry contract stores the profile on-chain and emits an `issuer_registered` event.
+
+**Buyer flow:**
+
+The SME shares the app link with their corporate counterparty. The buyer connects their Freighter wallet and completes an equivalent one-time `register_buyer` transaction before any invoice referencing their address can be created.
+
+**Liquidity Provider (LP) flow:**
+
+LPs do not need a separate registration step. Connecting a funded Freighter wallet is sufficient to deposit USDC into the pool and receive LP shares.
+
+**Profile verification:**
+
+The registry contract stores a `Profile` struct with `role` (`Issuer` or `Buyer`), a `verified` flag, `registered_at` timestamp, and arbitrary `metadata`. The admin can revoke verification at any time by setting `verified = false`; revoked addresses cannot participate in new invoice transactions.
 
 ## Users
 


### PR DESCRIPTION
…

- PRODUCT.md: replace placeholder 'Register' section with real on-chain registration flow for SMEs, buyers, and LPs (Closes #361 )
- CONTRIBUTING.md: add pnpm typecheck bullet to PR checklist and a Type-Checking step to the Development Lifecycle (Closes #363 )
- CONTRIBUTING.md: split Testing section into TypeScript and Go subsections; remove misleading Go line from pnpm test sample output (Closes #362 )
- .gitignore: remove personal-workflow entries create_pr.ps1 and build_output.txt (Closes #367 )