### PR TITLE
Fix: [Easy] fix(web): type Horizon operation record instead of (op: any) (Auto-Generated)

### DIFF
--- a/apps/web/hooks/useTxHistory.ts
+++ b/apps/web/hooks/useTxHistory.ts
@@ -36,20 +36,39 @@ const FUNCTION_LABELS: Record<string, string> = {
   handle_default: "Handle Default",
 };
 
+interface HorizonAssetBalanceChange {
+  from?: string;
+  to?: string;
+  amount?: string;
+  asset_type?: string;
+  asset_code?: string;
+}
+
+interface HorizonOperationRecord {
+  type?: string;
+  type_i?: number;
+  amount?: string;
+  asset_type?: string;
+  asset_code?: string;
+  contract_id?: string;
+  function?: string;
+  asset_balance_changes?: HorizonAssetBalanceChange[];
+}
+
 function getTxType(funcName: string): string {
   return FUNCTION_LABELS[funcName] || "Contract Invocation";
 }
 
 export function extractOpAmount(
-  op: any,
+  op: HorizonOperationRecord,
   userAddress: string,
 ): { amount: string; token: string } | undefined {
-  const type: string = op.type;
-  const typeI: number = op.type_i;
+  const type = op.type;
+  const typeI = op.type_i;
 
   if (type === "payment" || typeI === 1) {
-    const amount: string = op.amount;
-    const token: string = op.asset_type === "native" ? "XLM" : op.asset_code;
+    const amount = op.amount;
+    const token = op.asset_type === "native" ? "XLM" : op.asset_code;
     if (!amount || !token) return undefined;
     return { amount, token };
   }
@@ -57,11 +76,11 @@ export function extractOpAmount(
   if (type === "invoke_host_function" || typeI === 24) {
     if (!op.asset_balance_changes?.length) return undefined;
     const relevant = op.asset_balance_changes.find(
-      (change: any) => change.from === userAddress || change.to === userAddress,
+      (change) => change.from === userAddress || change.to === userAddress,
     );
     if (relevant) {
-      const amount: string = relevant.amount;
-      const token: string =
+      const amount = relevant.amount;
+      const token =
         relevant.asset_type === "native" ? "XLM" : relevant.asset_code;
       if (!amount || !token) return undefined;
       return { amount, token };
@@ -116,15 +135,15 @@ async function fetchPage(address: string, cursor?: string) {
 
     if (opsResult.status === "rejected") continue;
 
-    const ops = opsResult.value.records;
+    const ops = opsResult.value.records as HorizonOperationRecord[];
     const matchingOps = ops.filter(
-      (op: any) => op.contract_id && CONTRACT_IDS.includes(op.contract_id),
+      (op) => op.contract_id && CONTRACT_IDS.includes(op.contract_id),
     );
 
     if (matchingOps.length === 0) continue;
 
-    const mainOp = matchingOps[0] as any;
-    const type = getTxType(mainOp.function);
+    const mainOp = matchingOps[0];
+    const type = getTxType(mainOp.function ?? "");
     const amountToken = extractOpAmount(mainOp, address);
 
     items.push({


### PR DESCRIPTION
Closes #295

This PR was generated by the DripTide AI coder and scoped strictly to issue #295.

### Changes
Replaced the implicit any-based Horizon operation handling with explicit HorizonOperationRecord and HorizonAssetBalanceChange interfaces, and updated extractOpAmount to use the typed operation record.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #295` so the Drips Wave bot resolves the issue on merge._