### PR TITLE
Fix: [Easy] fix(web): replace raw: any in manuallyParse (Auto-Generated)

### DIFF
--- a/apps/web/lib/parsers.ts
+++ b/apps/web/lib/parsers.ts
@@ -1,8 +1,14 @@
 import { invoiceSchema } from "@trusttrove/sdk";
 import type { Invoice, AssetType } from "@/types";
 
-function normalizeKeys(obj: Record<string, unknown>): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
+type RawInvoice = Record<string, unknown>;
+
+function isRecord(value: unknown): value is RawInvoice {
+  return typeof value === "object" && value !== null;
+}
+
+function normalizeKeys(obj: RawInvoice): RawInvoice {
+  const result: RawInvoice = {};
   for (const [key, value] of Object.entries(obj ?? {})) {
     const camelKey = key.replace(/_([a-z0-9])/g, (_, letter) =>
       letter.toUpperCase(),
@@ -12,45 +18,63 @@ function normalizeKeys(obj: Record<string, unknown>): Record<string, unknown> {
   return result;
 }
 
-function manuallyParse(raw: any): Invoice {
+function toBigInt(value: unknown): bigint {
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number" || typeof value === "string") {
+    return BigInt(value);
+  }
+  return 0n;
+}
+
+function toNumber(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "bigint" || typeof value === "string") {
+    return Number(value);
+  }
+  return Number(value);
+}
+
+function toNullableNumber(value: unknown): number | null {
+  return value ? toNumber(value) : null;
+}
+
+function toStringValue(value: unknown): string {
+  return typeof value === "string" ? value : String(value ?? "");
+}
+
+function manuallyParse(raw: RawInvoice): Invoice {
+  const assetValue = raw.asset || "USDC";
+  const asset: AssetType = assetValue === "XLM" ? "XLM" : "USDC";
+
   return {
-    id: raw.id,
-    issuer: raw.issuer,
-    buyer: raw.buyer,
-    faceValue: BigInt(raw.face_value ?? raw.faceValue ?? 0),
-    asset: (raw.asset || "USDC") as AssetType,
-    discountBps: Number(raw.discount_bps ?? raw.discountBps ?? 0),
-    fundedAmount: BigInt(raw.funded_amount ?? raw.fundedAmount ?? 0),
-    dueDate: Number(raw.due_date ?? raw.dueDate ?? 0),
-    status: raw.status,
-    createdAt: Number(raw.created_at ?? raw.createdAt ?? 0),
-    fundedAt:
-      (raw.funded_at ?? raw.fundedAt)
-        ? Number(raw.funded_at ?? raw.fundedAt)
-        : null,
-    shippedAt:
-      (raw.shipped_at ?? raw.shippedAt)
-        ? Number(raw.shipped_at ?? raw.shippedAt)
-        : null,
+    id: toStringValue(raw.id),
+    issuer: toStringValue(raw.issuer),
+    buyer: toStringValue(raw.buyer),
+    faceValue: toBigInt(raw.face_value ?? raw.faceValue ?? 0),
+    asset,
+    discountBps: toNumber(raw.discount_bps ?? raw.discountBps ?? 0),
+    fundedAmount: toBigInt(raw.funded_amount ?? raw.fundedAmount ?? 0),
+    dueDate: toNumber(raw.due_date ?? raw.dueDate ?? 0),
+    status: toStringValue(raw.status) as Invoice["status"],
+    createdAt: toNumber(raw.created_at ?? raw.createdAt ?? 0),
+    fundedAt: toNullableNumber(raw.funded_at ?? raw.fundedAt),
+    shippedAt: toNullableNumber(raw.shipped_at ?? raw.shippedAt),
     issuerConfirmed: !!(raw.issuer_confirmed ?? raw.issuerConfirmed),
     buyerConfirmed: !!(raw.buyer_confirmed ?? raw.buyerConfirmed),
-    repaidAt:
-      (raw.repaid_at ?? raw.repaidAt)
-        ? Number(raw.repaid_at ?? raw.repaidAt)
-        : null,
+    repaidAt: toNullableNumber(raw.repaid_at ?? raw.repaidAt),
   };
 }
 
-function extraFields(raw: any) {
+function extraFields(raw: RawInvoice) {
   return {
-    listedAt: raw.listed_at ? Number(raw.listed_at) : null,
+    listedAt: raw.listed_at ? toNumber(raw.listed_at) : null,
     issuerConfirmedAt: raw.issuer_confirmed_at
-      ? Number(raw.issuer_confirmed_at)
+      ? toNumber(raw.issuer_confirmed_at)
       : null,
     buyerConfirmedAt: raw.buyer_confirmed_at
-      ? Number(raw.buyer_confirmed_at)
+      ? toNumber(raw.buyer_confirmed_at)
       : null,
-    defaultedAt: raw.defaulted_at ? Number(raw.defaulted_at) : null,
+    defaultedAt: raw.defaulted_at ? toNumber(raw.defaulted_at) : null,
     transactionHashes: raw.transaction_hashes,
     txHashes: raw.tx_hashes,
     createdTxHash: raw.created_tx_hash,
@@ -64,8 +88,8 @@ function extraFields(raw: any) {
   };
 }
 
-export function parseInvoiceResponse(raw: any): Invoice {
-  if (!raw || typeof raw !== "object") {
+export function parseInvoiceResponse(raw: unknown): Invoice {
+  if (!isRecord(raw)) {
     throw new Error("Invalid invoice payload");
   }
 


### PR DESCRIPTION
Closes #294

This PR was generated by the DripTide AI coder and scoped strictly to issue #294.

### Changes
Replaced the explicit any usage in manuallyParse and extraFields with a RawInvoice Record<string, unknown> type, added an unknown-to-record type guard, and added safe value conversion helpers. The parser now validates unknown input before normalization and schema parsing.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #294` so the Drips Wave bot resolves the issue on merge._