### PR TITLE
fix(indexer): api/router.go -- per-client rate limiting instead of gl…

### DIFF
--- a/indexer/api/router.go
+++ b/indexer/api/router.go
@@ -111,48 +111,124 @@ func SecurityHeadersMiddleware() func(http.Handler) http.Handler {
 	}
 }
 
-type rateLimiter struct {
+type clientBucket struct {
 	mu     sync.Mutex
 	tokens float64
 	last   time.Time
-	rps    float64
-	burst  int
 }
 
-func newRateLimiter(rps int, burst int) *rateLimiter {
-	return &rateLimiter{
-		tokens: float64(burst),
-		last:   time.Now(),
-		rps:    float64(rps),
-		burst:  burst,
+type perClientRateLimiter struct {
+	mu       sync.RWMutex
+	buckets  map[string]*clientBucket
+	rps      float64
+	burst    int
+	maxSize  int
+	done     chan struct{}
+}
+
+func newPerClientRateLimiter(rps int, burst int, maxSize int) *perClientRateLimiter {
+	rl := &perClientRateLimiter{
+		buckets: make(map[string]*clientBucket),
+		rps:     float64(rps),
+		burst:   burst,
+		maxSize: maxSize,
+		done:    make(chan struct{}),
 	}
+	go rl.cleanupLoop()
+	return rl
 }
 
-func (rl *rateLimiter) allow() bool {
+func (rl *perClientRateLimiter) Stop() {
+	close(rl.done)
+}
+
+func (rl *perClientRateLimiter) allow(clientKey string) bool {
 	rl.mu.Lock()
-	defer rl.mu.Unlock()
+	bucket, ok := rl.buckets[clientKey]
+	if !ok {
+		bucket = &clientBucket{
+			tokens: float64(rl.burst),
+			last:   time.Now(),
+		}
+		rl.buckets[clientKey] = bucket
+		if len(rl.buckets) > rl.maxSize {
+			rl.evictOldest()
+		}
+	}
+	rl.mu.Unlock()
+
+	bucket.mu.Lock()
+	defer bucket.mu.Unlock()
 
 	now := time.Now()
-	elapsed := now.Sub(rl.last).Seconds()
-	rl.tokens += elapsed * rl.rps
-	if rl.tokens > float64(rl.burst) {
-		rl.tokens = float64(rl.burst)
+	elapsed := now.Sub(bucket.last).Seconds()
+	bucket.tokens += elapsed * rl.rps
+	if bucket.tokens > float64(rl.burst) {
+		bucket.tokens = float64(rl.burst)
 	}
-	rl.last = now
+	bucket.last = now
 
-	if rl.tokens >= 1 {
-		rl.tokens--
+	if bucket.tokens >= 1 {
+		bucket.tokens--
 		return true
 	}
 	return false
 }
 
-func RateLimitMiddleware(rl *rateLimiter) func(http.Handler) http.Handler {
+func (rl *perClientRateLimiter) evictOldest() {
+	var oldestKey string
+	var oldestTime time.Time
+	for key, bucket := range rl.buckets {
+		if oldestKey == "" || bucket.last.Before(oldestTime) {
+			oldestKey = key
+			oldestTime = bucket.last
+		}
+	}
+	if oldestKey != "" {
+		delete(rl.buckets, oldestKey)
+	}
+}
+
+func (rl *perClientRateLimiter) cleanupLoop() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			rl.evictStale()
+		case <-rl.done:
+			return
+		}
+	}
+}
+
+func (rl *perClientRateLimiter) evictStale() {
+	cutoff := time.Now().Add(-10 * time.Minute)
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	for key, bucket := range rl.buckets {
+		bucket.mu.Lock()
+		if bucket.last.Before(cutoff) {
+			delete(rl.buckets, key)
+		}
+		bucket.mu.Unlock()
+	}
+}
+
+func getClientKey(r *http.Request) string {
+	if sub, ok := GetUserAddress(r.Context()); ok {
+		return "jwt:" + sub
+	}
+	return "ip:" + r.RemoteAddr
+}
+
+func RateLimitMiddleware(rl *perClientRateLimiter) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if !rl.allow() {
+			clientKey := getClientKey(r)
+			if !rl.allow(clientKey) {
 				w.Header().Set("Retry-After", "1")
-				http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+				http.Error(w, fmt.Sprintf("Too Many Requests (client: %s)", clientKey), http.StatusTooManyRequests)
 				return
 			}
 			next.ServeHTTP(w, r)
@@ -171,8 +247,9 @@ func NewRouter(h *APIHandler) *chi.Mux {
 	r.Use(CORSMiddleware(h.cfg.CORSAllowedOrigins))
 	r.Use(SecurityHeadersMiddleware())
 
-	// Global rate limiter for auth and invoice creation
-	rl := newRateLimiter(h.cfg.RateLimitRPS, h.cfg.RateLimitRPS*2)
+	// Per-client rate limiter for auth and invoice creation
+	// Max 1000 clients to bound memory usage
+	rl := newPerClientRateLimiter(h.cfg.RateLimitRPS, h.cfg.RateLimitRPS*2, 1000)
 
 	// Health check
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/indexer/api/router.go
+++ b/indexer/api/router.go
@@ -118,12 +118,12 @@ type clientBucket struct {
 }
 
 type perClientRateLimiter struct {
-	mu       sync.RWMutex
-	buckets  map[string]*clientBucket
-	rps      float64
-	burst    int
-	maxSize  int
-	done     chan struct{}
+	mu      sync.RWMutex
+	buckets map[string]*clientBucket
+	rps     float64
+	burst   int
+	maxSize int
+	done    chan struct{}
 }
 
 func newPerClientRateLimiter(rps int, burst int, maxSize int) *perClientRateLimiter {

--- a/indexer/api/router_test.go
+++ b/indexer/api/router_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -199,5 +200,151 @@ func TestAuthMiddleware_StrictHeaderParsing(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestPerClientRateLimiter_ClientIsolation(t *testing.T) {
+	rl := newPerClientRateLimiter(10, 20, 1000)
+	defer rl.Stop()
+
+	// Simulate client A exhausting its rate limit
+	clientA := "ip:192.168.1.100"
+	for i := 0; i < 25; i++ {
+		rl.allow(clientA)
+	}
+
+	// Client A should now be rate limited
+	if rl.allow(clientA) {
+		t.Error("client A should be rate limited after exhausting tokens")
+	}
+
+	// Client B should still be allowed (isolation)
+	clientB := "ip:192.168.1.101"
+	if !rl.allow(clientB) {
+		t.Error("client B should not be affected by client A's rate limit")
+	}
+}
+
+func TestPerClientRateLimiter_JWTvsIPKeys(t *testing.T) {
+	rl := newPerClientRateLimiter(10, 20, 1000)
+	defer rl.Stop()
+
+	// Create a request with JWT context
+	reqJWT := httptest.NewRequest(http.MethodPost, "/auth", nil)
+	ctx := WithUserAddress(reqJWT.Context(), "G1234567890")
+	reqJWT = reqJWT.WithContext(ctx)
+
+	// Create a request without JWT (IP-based)
+	reqIP := httptest.NewRequest(http.MethodPost, "/auth", nil)
+	reqIP.RemoteAddr = "192.168.1.100:12345"
+
+	keyJWT := getClientKey(reqJWT)
+	keyIP := getClientKey(reqIP)
+
+	if keyJWT != "jwt:G1234567890" {
+		t.Errorf("expected JWT key 'jwt:G1234567890', got %s", keyJWT)
+	}
+
+	if !strings.HasPrefix(keyIP, "ip:") {
+		t.Errorf("expected IP key to start with 'ip:', got %s", keyIP)
+	}
+
+	// Exhaust JWT client
+	for i := 0; i < 25; i++ {
+		rl.allow(keyJWT)
+	}
+
+	// JWT client should be rate limited
+	if rl.allow(keyJWT) {
+		t.Error("JWT client should be rate limited")
+	}
+
+	// IP client should still be allowed (different keys)
+	if !rl.allow(keyIP) {
+		t.Error("IP client should not be affected by JWT client's rate limit")
+	}
+}
+
+func TestPerClientRateLimiter_MaxSizeEviction(t *testing.T) {
+	maxSize := 10
+	rl := newPerClientRateLimiter(10, 20, maxSize)
+	defer rl.Stop()
+
+	// Add more clients than maxSize
+	for i := 0; i < maxSize+5; i++ {
+		clientKey := fmt.Sprintf("ip:192.168.1.%d", i)
+		rl.allow(clientKey)
+	}
+
+	rl.mu.RLock()
+	bucketCount := len(rl.buckets)
+	rl.mu.RUnlock()
+
+	// Bucket count should not exceed maxSize significantly
+	// (may be maxSize+1 due to race condition during eviction)
+	if bucketCount > maxSize+1 {
+		t.Errorf("bucket count %d exceeds maxSize %d", bucketCount, maxSize)
+	}
+}
+
+func TestPerClientRateLimiter_StaleEviction(t *testing.T) {
+	rl := newPerClientRateLimiter(10, 20, 1000)
+	defer rl.Stop()
+
+	// Add a client
+	clientKey := "ip:192.168.1.100"
+	rl.allow(clientKey)
+
+	rl.mu.RLock()
+	_, exists := rl.buckets[clientKey]
+	rl.mu.RUnlock()
+
+	if !exists {
+		t.Error("client bucket should exist after allow")
+	}
+
+	// Manually set lastSeen to old time
+	rl.mu.Lock()
+	if bucket, ok := rl.buckets[clientKey]; ok {
+		bucket.mu.Lock()
+		bucket.last = time.Now().Add(-15 * time.Minute)
+		bucket.mu.Unlock()
+	}
+	rl.mu.Unlock()
+
+	// Trigger cleanup
+	rl.evictStale()
+
+	rl.mu.RLock()
+	_, exists = rl.buckets[clientKey]
+	rl.mu.RUnlock()
+
+	if exists {
+		t.Error("stale client bucket should be evicted")
+	}
+}
+
+func TestPerClientRateLimiter_TokenRefill(t *testing.T) {
+	rl := newPerClientRateLimiter(100, 20, 1000)
+	defer rl.Stop()
+
+	clientKey := "ip:192.168.1.100"
+
+	// Exhaust burst
+	for i := 0; i < 25; i++ {
+		rl.allow(clientKey)
+	}
+
+	// Should be rate limited
+	if rl.allow(clientKey) {
+		t.Error("should be rate limited after exhausting burst")
+	}
+
+	// Wait for token refill
+	time.Sleep(20 * time.Millisecond)
+
+	// Should be allowed again after refill
+	if !rl.allow(clientKey) {
+		t.Error("should be allowed after token refill")
 	}
 }


### PR DESCRIPTION
…obal

I've implemented the per-client rate limiter to replace the global one. Here's what was done:

Changes Made
router.go:

Replaced global rateLimiter with perClientRateLimiter that maintains separate token buckets per client
Added getClientKey() function to key by JWT subject for authenticated routes (jwt:G123...) or IP for anonymous routes (ip:192.168.1.100)
Implemented LRU eviction when map exceeds maxSize (set to 1000 clients)
Added background cleanup loop to evict stale entries (10+ minutes inactive)
Updated error messages to include the rejected client ID
Added Stop() method for graceful shutdown
router_test.go:

Added 5 comprehensive tests:
TestPerClientRateLimiter_ClientIsolation - verifies one client can't affect another
TestPerClientRateLimiter_JWTvsIPKeys - verifies JWT and IP keys are separate
TestPerClientRateLimiter_MaxSizeEviction - verifies map stays bounded
TestPerClientRateLimiter_StaleEviction - verifies stale entries are cleaned up
TestPerClientRateLimiter_TokenRefill - verifies token refill works correctly
All tests pass. The implementation meets all acceptance criteria:

✅ One misbehaving client cannot rate-limit others
✅ The limiter map is bounded (LRU eviction + stale cleanup)
✅ Tests cover isolation between two clients


Closes #318
Closes #319
Closes #320
Closes #321