### PR TITLE
Fix: [Easy] chore(web): remove duplicate /sme route that re-exports /dashboard (Auto-Generated)

### DIFF
--- a/apps/web/app/sme/page.tsx
+++ b/apps/web/app/sme/page.tsx
@@ -1,1 +1,0 @@
-export { default } from "../dashboard/page";


### PR DESCRIPTION
Closes #288

This PR was generated by the DripTide AI coder and scoped strictly to issue #288.

### Changes
Removed the duplicate apps/web/app/sme/page.tsx route so /sme no longer re-exports /dashboard and will return 404.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #288` so the Drips Wave bot resolves the issue on merge._