### PR TITLE
Fix: [Easy] fix(web): footer placeholder href=# links in landing page (Auto-Generated)

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -19,6 +19,11 @@ import {
   Landmark,
 } from "lucide-react";
 
+const specificationUrl = "https://k1ngd4vid.gitbook.io/trustrove/";
+const stellarExpertUrl = process.env.NEXT_PUBLIC_POOL_CONTRACT_ID
+  ? `https://stellar.expert/explorer/testnet/contract/${process.env.NEXT_PUBLIC_POOL_CONTRACT_ID}`
+  : "https://stellar.expert/explorer/testnet";
+
 export default function Home() {
   const { stats, isStatsLoading, statsError } = usePool();
 
@@ -317,10 +322,20 @@ export default function Home() {
         <div className="max-w-7xl mx-auto px-4 flex flex-col md:flex-row items-center justify-between gap-4">
           <span>© 2026 TRUSTROVE PROTOCOL — VERIFIED TRADE FINANCE</span>
           <div className="flex gap-4">
-            <a href="#" className="hover:text-primary transition-colors">
+            <a
+              href={specificationUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-primary transition-colors"
+            >
               SPECIFICATION
             </a>
-            <a href="#" className="hover:text-primary transition-colors">
+            <a
+              href={stellarExpertUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-primary transition-colors"
+            >
               STELLAR EXPERT
             </a>
             <Link href="/docs" className="hover:text-primary transition-colors">


### PR DESCRIPTION
Closes #282

This PR was generated by the DripTide AI coder and scoped strictly to issue #282.

### Changes
Replaced the footer placeholder links with a GitBook specification URL and a Stellar Expert contract URL derived from the public pool contract environment variable. Both external links now open in a new tab with noopener and noreferrer protections.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #282` so the Drips Wave bot resolves the issue on merge._