### PR TITLE
Fix: [Easy] chore(web): useAppError has one broken consumer -- either broaden usage or delete (Auto-Generated)

### DIFF
--- a/apps/web/hooks/useAuth.test.ts
+++ b/apps/web/hooks/useAuth.test.ts
@@ -71,7 +71,9 @@ describe("useAuth", () => {
     await act(async () => {
       await result.current.login();
     });
-    expect(result.current.error).toBe("Wallet not connected");
+    expect(result.current.error).toBe(
+      "Please connect your wallet to perform this action",
+    );
     expect(result.current.loading).toBe(false);
   });
 

--- a/apps/web/hooks/useAuth.ts
+++ b/apps/web/hooks/useAuth.ts
@@ -7,6 +7,7 @@ import {
   initApiClientWithToken,
 } from "@/lib/api";
 import { createErrorHandler } from "@/lib/errors";
+import { useAppError } from "./useAppError";
 
 const { captureError } = createErrorHandler("useAuth");
 
@@ -37,7 +38,7 @@ const { captureError } = createErrorHandler("useAuth");
 export function useAuth() {
   const { address, token, setToken, disconnect } = useWalletStore();
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { error, handleError, clearError } = useAppError();
 
   /**
    * Initiates the SEP-10 wallet authentication flow using the api utility functions.
@@ -46,12 +47,12 @@ export function useAuth() {
    */
   const login = async () => {
     if (!address) {
-      setError("Wallet not connected");
+      handleError(new Error("Wallet not connected"));
       return;
     }
 
     setLoading(true);
-    setError(null);
+    clearError();
 
     try {
       const { transaction, network_passphrase } = await fetchChallenge(address);
@@ -70,7 +71,7 @@ export function useAuth() {
       initApiClientWithToken();
     } catch (err: unknown) {
       const appError = captureError(err);
-      setError(appError.message);
+      handleError(appError);
       setToken(null);
       initApiClientWithToken();
     } finally {
@@ -85,6 +86,7 @@ export function useAuth() {
     setToken(null);
     initApiClientWithToken();
     disconnect();
+    clearError();
   };
 
   return {

--- a/apps/web/hooks/usePool.ts
+++ b/apps/web/hooks/usePool.ts
@@ -6,6 +6,7 @@ import { useWalletStore } from "@/store/wallet";
 import { showSuccessToast } from "@/lib/toast";
 import { createErrorHandler } from "@/lib/errors";
 import { useTokenAllowance } from "./useTokenAllowance";
+import { useAppError } from "./useAppError";
 import type { AssetType } from "@/types";
 
 const { handleMutationError } = createErrorHandler("usePool");
@@ -28,6 +29,7 @@ export function usePool() {
   const queryClient = useQueryClient();
   const { address } = useWalletStore();
   const { ensureAllowance } = useTokenAllowance();
+  const { error: appError, handleError, clearError } = useAppError();
 
   const poolClient = useMemo(() => new PoolClient(poolContractID), []);
 
@@ -58,12 +60,14 @@ export function usePool() {
       return poolClient.deposit(address, amount, address);
     },
     onSuccess: (txHash: string) => {
+      clearError();
       queryClient.invalidateQueries({ queryKey: ["poolStats"] });
       queryClient.invalidateQueries({ queryKey: ["lpPosition", address] });
       showSuccessToast("Deposit Complete", txHash);
     },
     onError: (error) => {
       handleMutationError(error, "Deposit Failed");
+      handleError(error, "Deposit failed");
     },
   });
 
@@ -75,12 +79,14 @@ export function usePool() {
       return poolClient.withdraw(address, shares, address);
     },
     onSuccess: (txHash: string) => {
+      clearError();
       queryClient.invalidateQueries({ queryKey: ["poolStats"] });
       queryClient.invalidateQueries({ queryKey: ["lpPosition", address] });
       showSuccessToast("Withdrawal Complete", txHash);
     },
     onError: (error) => {
       handleMutationError(error, "Withdrawal Failed");
+      handleError(error, "Withdrawal failed");
     },
   });
 
@@ -102,5 +108,7 @@ export function usePool() {
     withdraw: withdrawMutation.mutateAsync,
     isWithdrawing: withdrawMutation.isPending,
     withdrawError: withdrawMutation.error,
+
+    appError,
   };
 }

--- a/apps/web/hooks/useProfile.ts
+++ b/apps/web/hooks/useProfile.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { RegistryClient, Profile } from "@trusttrove/sdk";
 import { useWalletStore } from "@/store/wallet";
 import { createErrorHandler } from "@/lib/errors";
+import { useAppError } from "./useAppError";
 
 const { captureError } = createErrorHandler("useProfile");
 
@@ -63,6 +64,7 @@ function isProfileNotFoundError(error: unknown): boolean {
 export function useProfile() {
   const queryClient = useQueryClient();
   const { address } = useWalletStore();
+  const { error: appError, handleError, clearError } = useAppError();
 
   const profileQuery = useQuery({
     queryKey: ["profile", address],
@@ -117,11 +119,13 @@ export function useProfile() {
       }
     },
     onSuccess: () => {
+      clearError();
       queryClient.invalidateQueries({ queryKey: ["profile", address] });
       queryClient.invalidateQueries({ queryKey: ["isVerified", address] });
     },
     onError: (error) => {
       captureError(error);
+      handleError(error, "Profile registration failed");
     },
   });
 
@@ -137,6 +141,7 @@ export function useProfile() {
     register: registerMutation.mutateAsync,
     isRegistering: registerMutation.isPending,
     registerError: registerMutation.error,
+    appError,
 
     refetchProfile: async () => {
       await Promise.all([profileQuery.refetch(), isVerifiedQuery.refetch()]);


### PR DESCRIPTION
Closes #289

This PR was generated by the DripTide AI coder and scoped strictly to issue #289.

### Changes
Integrated useAppError into three additional hooks: useAuth, useProfile, and usePool. Authentication, profile registration, and pool mutation errors are now captured and exposed through the shared application error state, satisfying the requirement for at least three consumers.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #289` so the Drips Wave bot resolves the issue on merge._