### PR TITLE
Fix: [Medium] fix(indexer): db/queries.go -- OR-with-empty pattern defeats index on GetInvoicesPage (Auto-Generated)

### DIFF
--- a/indexer/db/queries.go
+++ b/indexer/db/queries.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -136,14 +137,26 @@ func GetInvoiceByID(ctx context.Context, id string) (*DbInvoice, error) {
 }
 
 func GetInvoicesPage(ctx context.Context, status, issuer string, limit, offset int) ([]*DbInvoice, int, error) {
-	countQuery := `
-		SELECT COUNT(*)
-		FROM invoices
-		WHERE ($1 = '' OR status = $1)
-		  AND ($2 = '' OR issuer = $2)
-	`
+	predicates := make([]string, 0, 2)
+	args := make([]any, 0, 2)
+
+	if status != "" {
+		args = append(args, status)
+		predicates = append(predicates, fmt.Sprintf("status = $%d", len(args)))
+	}
+	if issuer != "" {
+		args = append(args, issuer)
+		predicates = append(predicates, fmt.Sprintf("issuer = $%d", len(args)))
+	}
+
+	whereClause := ""
+	if len(predicates) > 0 {
+		whereClause = " WHERE " + strings.Join(predicates, " AND ")
+	}
+
+	countQuery := "SELECT COUNT(*) FROM invoices" + whereClause
 	var total int
-	if err := Pool.QueryRow(ctx, countQuery, status, issuer).Scan(&total); err != nil {
+	if err := Pool.QueryRow(ctx, countQuery, args...).Scan(&total); err != nil {
 		return nil, 0, fmt.Errorf("queries: count invoices: %w", err)
 	}
 
@@ -151,13 +164,12 @@ func GetInvoicesPage(ctx context.Context, status, issuer string, limit, offset i
 		SELECT 
 			id, issuer, buyer, face_value, discount_bps, funded_amount, due_date, status, created_at,
 			funded_at, shipped_at, issuer_confirmed, buyer_confirmed, buyer_confirmed_at, repaid_at
-		FROM invoices
-		WHERE ($1 = '' OR status = $1)
-		  AND ($2 = '' OR issuer = $2)
+		FROM invoices` + whereClause + fmt.Sprintf(`
 		ORDER BY created_at DESC
-		LIMIT $3 OFFSET $4
-	`
-	rows, err := Pool.Query(ctx, query, status, issuer, limit, offset)
+		LIMIT $%d OFFSET $%d`, len(args)+1, len(args)+2)
+	queryArgs := append(args, limit, offset)
+
+	rows, err := Pool.Query(ctx, query, queryArgs...)
 	if err != nil {
 		return nil, 0, fmt.Errorf("queries: get invoices: %w", err)
 	}


### PR DESCRIPTION
Closes #329

This PR was generated by the DripTide AI coder and scoped strictly to issue #329.

### Changes
Updated GetInvoicesPage to construct filter predicates and SQL arguments dynamically, eliminating OR-with-empty predicates and allowing PostgreSQL to use applicable status, issuer, and created_at indexes.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #329` so the Drips Wave bot resolves the issue on merge._