### PR TITLE
Fix: [Easy] fix(web): narrow setRole(e.target.value as any) to the role union (Auto-Generated)

### DIFF
--- a/apps/web/components/shared/Navbar.tsx
+++ b/apps/web/components/shared/Navbar.tsx
@@ -9,6 +9,12 @@ import { useWalletStore } from '@/store/wallet';
 import { useBalances } from '@/hooks/useBalances';
 import { Wallet, Shield, Terminal, ExternalLink } from 'lucide-react';
 
+type Role = 'issuer' | 'buyer' | 'lp';
+
+function isRole(value: string): value is Role {
+  return value === 'issuer' || value === 'buyer' || value === 'lp';
+}
+
 export function Navbar() {
   const pathname = usePathname();
   const { role, setRole, connected } = useWalletStore();
@@ -100,7 +106,10 @@ export function Navbar() {
                   <span className="text-[10px] font-bold text-slate-500 font-mono uppercase tracking-wider hidden sm:inline">Role:</span>
                   <select
                     value={role}
-                    onChange={(e) => setRole(e.target.value as any)}
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      if (isRole(value)) setRole(value);
+                    }}
                     className="bg-transparent text-xs text-white border-none focus:ring-0 focus:outline-none font-bold font-mono cursor-pointer pr-5 py-0"
                   >
                     <option value="issuer" className="bg-[#080c10] text-slate-200">SME (Issuer)</option>


### PR DESCRIPTION
Closes #290

This PR was generated by the DripTide AI coder and scoped strictly to issue #290.

### Changes
Replaced the explicit any cast in Navbar's role selector with a Role union and an isRole type guard before calling setRole.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #290` so the Drips Wave bot resolves the issue on merge._