### PR TITLE
Fix: [Medium] fix(web): useProfile masks real errors behind 'not registered' UI (Auto-Generated)

### DIFF
--- a/apps/web/hooks/useProfile.ts
+++ b/apps/web/hooks/useProfile.ts
@@ -7,6 +7,42 @@ const { captureError } = createErrorHandler("useProfile");
 
 const registryContractID = process.env.NEXT_PUBLIC_REGISTRY_CONTRACT_ID || "";
 
+type ErrorWithResponse = {
+  status?: number;
+  statusCode?: number;
+  response?: {
+    status?: number;
+    statusCode?: number;
+  };
+};
+
+function getErrorStatus(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+
+  const errorWithResponse = error as ErrorWithResponse;
+  return (
+    errorWithResponse.status ??
+    errorWithResponse.statusCode ??
+    errorWithResponse.response?.status ??
+    errorWithResponse.response?.statusCode
+  );
+}
+
+function isProfileNotFoundError(error: unknown): boolean {
+  if (getErrorStatus(error) === 404) return true;
+
+  if (!(error instanceof Error)) return false;
+
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("profile not found") ||
+    message.includes("profile does not exist") ||
+    message.includes("no profile found") ||
+    message.includes("profile is not registered") ||
+    message.includes("profile not registered")
+  );
+}
+
 /**
  * Custom hook for interacting with the TrusTrove registry contract.
  *
@@ -37,10 +73,12 @@ export function useProfile() {
         const profile = await client.getProfile(address, address);
         return profile;
       } catch (err) {
-        // getProfile throws a simulation error if profile doesn't exist.
-        // We return null to indicate the profile is not registered.
+        if (isProfileNotFoundError(err)) {
+          return null;
+        }
+
         captureError(err);
-        return null;
+        throw err;
       }
     },
     enabled: !!address,


### PR DESCRIPTION
Closes #276

This PR was generated by the DripTide AI coder and scoped strictly to issue #276.

### Changes
Updated useProfile so profile lookup errors are only converted to null for recognized 404 or profile-not-found errors. Other errors are captured and re-thrown so React Query exposes them through profileError.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #276` so the Drips Wave bot resolves the issue on merge._