### PR TITLE
Fix: [Medium] fix(web): 'Switch to Testnet' button never actually asks Freighter to switch (Auto-Generated)

### DIFF
--- a/apps/web/components/shared/WalletConnect.tsx
+++ b/apps/web/components/shared/WalletConnect.tsx
@@ -15,6 +15,15 @@ import {
   ExternalLink,
 } from "lucide-react";
 
+interface FreighterNetworkApi {
+  setNetwork?: (network: string) => Promise<unknown>;
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error) return error.message;
+  return "Freighter could not switch networks";
+}
+
 export function WalletConnect() {
   const {
     address,
@@ -29,6 +38,10 @@ export function WalletConnect() {
   const { network } = useWalletStore();
   const [installed, setInstalled] = useState<boolean | null>(null);
   const [copied, setCopied] = useState(false);
+  const [switchingNetwork, setSwitchingNetwork] = useState(false);
+  const [networkSwitchError, setNetworkSwitchError] = useState<string | null>(
+    null,
+  );
 
   useEffect(() => {
     isFreighterInstalled().then(setInstalled);
@@ -39,6 +52,39 @@ export function WalletConnect() {
     await navigator.clipboard.writeText(address);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleSwitchToTestnet = async () => {
+    setSwitchingNetwork(true);
+    setNetworkSwitchError(null);
+
+    try {
+      const freighter = (await import(
+        "@stellar/freighter-api"
+      )) as unknown as FreighterNetworkApi;
+
+      if (typeof freighter.setNetwork !== "function") {
+        throw new Error(
+          "Your Freighter version does not support network switching from this app.",
+        );
+      }
+
+      const response = await freighter.setNetwork("TESTNET");
+      if (
+        response &&
+        typeof response === "object" &&
+        "error" in response &&
+        response.error
+      ) {
+        throw new Error(String(response.error));
+      }
+
+      await connectWallet();
+    } catch (error) {
+      setNetworkSwitchError(getErrorMessage(error));
+    } finally {
+      setSwitchingNetwork(false);
+    }
   };
 
   const formatAddress = (addr: string) => {
@@ -64,26 +110,53 @@ export function WalletConnect() {
     <div className="flex flex-col gap-2 md:flex-row md:items-center">
       {/* Network Badge */}
       {connected && (
-        <div className="flex items-center gap-2">
-          {network === "testnet" ? (
-            <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-amber-500/10 border border-amber-500/20 text-amber-400 font-mono">
-              <span className="w-1.5 h-1.5 rounded-full bg-amber-500 animate-pulse" />
-              Testnet
-            </span>
-          ) : network === "mainnet" ? (
-            <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 font-mono">
-              <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
-              Mainnet
-            </span>
-          ) : (
-            <Button
-              variant="outline"
-              size="sm"
-              className="text-xs border-amber-500/30 text-amber-500 hover:bg-amber-500/10 rounded-md font-mono"
-              onClick={connectWallet}
-            >
-              Switch to Testnet
-            </Button>
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            {network === "testnet" ? (
+              <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-amber-500/10 border border-amber-500/20 text-amber-400 font-mono">
+                <span className="w-1.5 h-1.5 rounded-full bg-amber-500 animate-pulse" />
+                Testnet
+              </span>
+            ) : network === "mainnet" ? (
+              <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 font-mono">
+                <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
+                Mainnet
+              </span>
+            ) : (
+              <Button
+                variant="outline"
+                size="sm"
+                className="text-xs border-amber-500/30 text-amber-500 hover:bg-amber-500/10 rounded-md font-mono"
+                onClick={handleSwitchToTestnet}
+                disabled={switchingNetwork}
+              >
+                {switchingNetwork && (
+                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                )}
+                {switchingNetwork ? "SWITCHING..." : "Switch to Testnet"}
+              </Button>
+            )}
+          </div>
+
+          {networkSwitchError && (
+            <div className="flex flex-col gap-1 text-xs text-amber-400 bg-amber-500/10 border border-amber-500/20 rounded-md px-2.5 py-2">
+              <span className="flex items-start gap-1.5">
+                <AlertCircle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                <span>
+                  Open Freighter, switch its network to Testnet, then reconnect
+                  your wallet.
+                </span>
+              </span>
+              <a
+                href="https://www.freighter.app/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 font-semibold hover:underline"
+              >
+                <span>Open Freighter</span>
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            </div>
           )}
         </div>
       )}

--- a/apps/web/components/shared/WalletConnect.tsx
+++ b/apps/web/components/shared/WalletConnect.tsx
@@ -59,9 +59,8 @@ export function WalletConnect() {
     setNetworkSwitchError(null);
 
     try {
-      const freighter = (await import(
-        "@stellar/freighter-api"
-      )) as unknown as FreighterNetworkApi;
+      const freighter =
+        (await import("@stellar/freighter-api")) as unknown as FreighterNetworkApi;
 
       if (typeof freighter.setNetwork !== "function") {
         throw new Error(


### PR DESCRIPTION
Closes #273

This PR was generated by the DripTide AI coder and scoped strictly to issue #273.

### Changes
Replaced the silent connectWallet no-op with a Freighter network-switch request targeting TESTNET, refreshed wallet state after success, added loading feedback, and provided actionable fallback instructions with an Open Freighter link when switching is unavailable or fails.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #273` so the Drips Wave bot resolves the issue on merge._