### PR TITLE
fix(indexer): surface Rollback errors and check json.Encode errors

### DIFF
--- a/indexer/api/handlers.go
+++ b/indexer/api/handlers.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"net/http"
 	"strconv"
@@ -55,6 +56,16 @@ func GetServerKeypair(seed string) (*keypair.Full, error) {
 		return nil, fmt.Errorf("empty server seed")
 	}
 	return keypair.ParseFull(seed)
+}
+
+// writeJSON sets the Content-Type header, writes the status code, encodes v as
+// JSON, and logs any encoding error at WARN level.
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Warn("failed to encode JSON response", "error", err)
+	}
 }
 
 func (h *APIHandler) ListenerHealth() *ListenerHealth {
@@ -445,8 +456,7 @@ func (h *APIHandler) HandleGetAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{
+	writeJSON(w, http.StatusOK, map[string]string{
 		"transaction":        xdrString,
 		"network_passphrase": h.cfg.NetworkPassphrase,
 	})
@@ -479,8 +489,7 @@ func (h *APIHandler) HandlePostAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{
+	writeJSON(w, http.StatusOK, map[string]string{
 		"token": token,
 	})
 }
@@ -709,9 +718,7 @@ func (h *APIHandler) HandleCreateInvoice(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusCreated)
-	json.NewEncoder(w).Encode(map[string]string{
+	writeJSON(w, http.StatusCreated, map[string]string{
 		"invoice_id":       invoiceID,
 		"transaction_hash": submitResp.Hash,
 		"status":           txResult.Status,
@@ -737,8 +744,7 @@ func (h *APIHandler) HandleGetInvoiceByID(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(invoice)
+	writeJSON(w, http.StatusOK, invoice)
 }
 
 // GET /invoices
@@ -798,8 +804,7 @@ func (h *APIHandler) HandleGetInvoices(w http.ResponseWriter, r *http.Request) {
 		"totalPages": totalPages,
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // GET /stats
@@ -809,8 +814,7 @@ func (h *APIHandler) HandleGetStats(w http.ResponseWriter, r *http.Request) {
 	if h.statsData != nil && time.Since(h.statsCached) < 30*time.Second {
 		data := h.statsData
 		h.statsMu.RUnlock()
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(data)
+		writeJSON(w, http.StatusOK, data)
 		return
 	}
 	h.statsMu.RUnlock()
@@ -822,8 +826,7 @@ func (h *APIHandler) HandleGetStats(w http.ResponseWriter, r *http.Request) {
 	if h.statsData != nil && time.Since(h.statsCached) < 30*time.Second {
 		data := h.statsData
 		h.statsMu.Unlock()
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(data)
+		writeJSON(w, http.StatusOK, data)
 		return
 	}
 
@@ -839,8 +842,7 @@ func (h *APIHandler) HandleGetStats(w http.ResponseWriter, r *http.Request) {
 	h.statsCached = time.Now()
 	h.statsMu.Unlock()
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(stats)
+	writeJSON(w, http.StatusOK, stats)
 }
 
 // GET /pool/stats
@@ -863,8 +865,7 @@ func (h *APIHandler) HandleGetPoolStats(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(stats)
+	writeJSON(w, http.StatusOK, stats)
 }
 
 // GET /events
@@ -887,8 +888,7 @@ func (h *APIHandler) HandleGetEvents(w http.ResponseWriter, r *http.Request) {
 		events = []*db.EventLog{}
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(events)
+	writeJSON(w, http.StatusOK, events)
 }
 
 // GET /pool/position/{address}
@@ -934,8 +934,7 @@ func (h *APIHandler) HandleGetLPPosition(w http.ResponseWriter, r *http.Request)
 		depositCount = int(xdrutil.ParseU32(val))
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
+	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"shares":        shares,
 		"usdc_value":    usdcValue,
 		"yield_earned":  yieldEarned,

--- a/indexer/db/db.go
+++ b/indexer/db/db.go
@@ -2,13 +2,16 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -85,7 +88,7 @@ func RunMigration(ctx context.Context) error {
 		}
 
 		if _, err := tx.Exec(ctx, string(migrationBytes)); err != nil {
-			tx.Rollback(ctx)
+			rollbackOnError(ctx, tx)
 			return fmt.Errorf("failed to execute migration %s: %w", filename, err)
 		}
 
@@ -93,7 +96,7 @@ func RunMigration(ctx context.Context) error {
 			INSERT INTO schema_migrations (version, applied_at)
 			VALUES ($1, $2)
 		`, version, time.Now().UTC()); err != nil {
-			tx.Rollback(ctx)
+			rollbackOnError(ctx, tx)
 			return fmt.Errorf("failed to record migration %s: %w", filename, err)
 		}
 
@@ -169,4 +172,13 @@ func loadAppliedMigrations(ctx context.Context) (map[string]bool, error) {
 	}
 
 	return applied, rows.Err()
+}
+
+// rollbackOnError rolls back the transaction and logs any unexpected error.
+// It ignores pgx.ErrTxClosed since that is expected when the transaction is
+// already closed.
+func rollbackOnError(ctx context.Context, tx pgx.Tx) {
+	if err := tx.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+		slog.Warn("transaction rollback failed", "error", err)
+	}
 }


### PR DESCRIPTION
#Closes #339 
#Closes #340

## Summary

### Issue #340: Surface Rollback errors in db/db.go

Adds a rollbackOnError helper that ignores pgx.ErrTxClosed but logs other rollback failures at WARN level via slog. Replaces both discarded tx.Rollback(ctx) call sites.

### Issue #339: Check json.Encode errors in api/handlers.go

Adds a writeJSON helper that sets Content-Type, writes the status code, encodes JSON, and logs any encode error at WARN level. Replaces all 11 json.NewEncoder(w).Encode(...) call sites with writeJSON, removing redundant header/status lines.

## Verification

- [x] go build ./... succeeds
- [x] go vet ./... clean
- [x] go test -v ./... green
- [x] gofmt -l . prints nothing