### PR TITLE
docs(repo): remove stray bracket markdown artifact from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <h1 align="center">TrusTrove</h1>
-[
+
 <p align="center">
   Decentralized trade finance on Stellar — SMEs get paid today, LPs earn yield, no banks involved.
 </p>


### PR DESCRIPTION
## Summary

Removes a stray `[` bracket on line 7 of README.md that was a leftover markdown artifact from an earlier edit.

## Changes

- `README.md`: Delete the lone `[` character sitting between the `<h1>` and the description paragraph

## Linked Issue

Closes #346

## Verification

- Markdown renders cleanly with no stray brackets