### PR TITLE
fix: [Easy] docs(indexer): fix invoice status enum values in openapi spec

### DIFF
--- a/docs/openapi/indexer.yaml
+++ b/docs/openapi/indexer.yaml
@@ -142,7 +142,7 @@ paths:
           required: false
           schema:
             type: string
-            enum: [pending, funded, shipped, delivered, repaid, defaulted]
+            enum: [Created, Listed, Funded, Active, Confirmed, Repaid, Defaulted]
         - name: issuer
           in: query
           required: false
@@ -384,6 +384,7 @@ components:
           format: int64
         status:
           type: string
+          enum: [Created, Listed, Funded, Active, Confirmed, Repaid, Defaulted]
         created_at:
           type: integer
           format: int64


### PR DESCRIPTION
## Summary
Fixed the invoice status enum values in `docs/openapi/indexer.yaml` to match the real status values used throughout the codebase.

Changes:
1. Updated the `GET /invoices` `status` query parameter enum (line 145) from `[pending, funded, shipped, delivered, repaid, defaulted]` to `[Created, Listed, Funded, Active, Confirmed, Repaid, Defaulted]` (case-sensitive PascalCase).
2. Applied the same enum to the `Invoice` schema's `status` field (line ~385) for consistency, as suggested in the issue's proposed approach step 2.

These values match `docs/developer-guide/indexer-api-reference.md` and `apps/web/components/invoice/InvoiceStatus.tsx`. No code changes were needed — pure Markdown/YAML documentation edits.

## Changed files
- `docs/openapi/indexer.yaml`

## Test plan
No code changes were made, so no unit tests are affected. CI jobs (`Verify TypeScript Frontend & SDK` and `Verify Go Indexer & API`) should remain green since this is a documentation-only change. Local verification: confirm the YAML remains valid and relative links resolve.

This PR was created as a draft by the issue solver bot. It will remain a
draft until repository CI passes.

Closes #566
