### PR TITLE
fix: [Easy] docs(for-smes): mention the verification requirement in create-your-first-invoice.md

### DIFF
--- a/docs/for-smes/create-your-first-invoice.md
+++ b/docs/for-smes/create-your-first-invoice.md
@@ -25,6 +25,11 @@ After creation, the invoice is in `Created` status. Go to the invoice detail pag
 and click **List for Financing**. Set your discount rate — the amount you are
 willing to give up to get paid today.
 
+Before an invoice can be listed, it is automatically checked against Underwrite's
+risk assessment. If that check hasn't finished yet, listing will be blocked for a
+few minutes — wait and try again. Once the check passes, the invoice is ready to
+list.
+
 Lower discount = cheaper but may take longer to fund.
 Higher discount = more expensive but attracts funders faster.
 


### PR DESCRIPTION
## Summary
Updated `docs/for-smes/create-your-first-invoice.md` Step 3 — List for Financing to mention the verification requirement in plain, SME-facing language. Added a short note explaining that invoices are automatically checked against Underwrite's risk assessment before they can be listed, and that if the check hasn't finished yet, listing will be blocked for a few minutes — the SME should wait and try again. No code changes; pure Markdown matching the existing tone/structure.

## Changed files
- `docs/for-smes/create-your-first-invoice.md`

## Test plan
No code changes were made, so no TypeScript/Go tests are affected. CI jobs (`Verify TypeScript Frontend & SDK` and `Verify Go Indexer & API`) should remain green since this is a pure Markdown documentation edit. Local verification: relative links are unchanged and resolve; the added text introduces no new links.

This PR was created as a draft by the issue solver bot. It will remain a
draft until repository CI passes.

Closes #573
