### PR TITLE
fix: [Easy] fix(web): enforce documented 7-365 day due-date bounds in InvoiceForm

### DIFF
--- a/apps/web/components/invoice/InvoiceForm.test.tsx
+++ b/apps/web/components/invoice/InvoiceForm.test.tsx
@@ -96,7 +96,9 @@ describe("InvoiceForm Component Boundary Tests", () => {
     // Enter a valid buyer address
     const buyerInput = screen.getByPlaceholderText(/stellar public key/i);
     fireEvent.change(buyerInput, {
-      target: { value: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF" },
+      target: {
+        value: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+      },
     });
 
     // Fill a valid face value
@@ -128,7 +130,9 @@ describe("InvoiceForm Component Boundary Tests", () => {
     // Enter a valid buyer address
     const buyerInput = screen.getByPlaceholderText(/stellar public key/i);
     fireEvent.change(buyerInput, {
-      target: { value: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF" },
+      target: {
+        value: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+      },
     });
 
     // Fill a valid face value

--- a/apps/web/components/invoice/InvoiceForm.test.tsx
+++ b/apps/web/components/invoice/InvoiceForm.test.tsx
@@ -11,7 +11,11 @@ vi.mock("@trusttrove/sdk", () => ({
 }));
 
 vi.mock("@stellar/stellar-sdk", () => ({
-  StrKey: { isValidEd25519PublicKey: vi.fn(() => false) },
+  StrKey: {
+    isValidEd25519PublicKey: vi.fn(
+      (value: string) => typeof value === "string" && value.startsWith("G"),
+    ),
+  },
   xdr: { ScVal: { scvBytes: vi.fn() } },
   nativeToScVal: vi.fn(),
 }));
@@ -83,6 +87,70 @@ describe("InvoiceForm Component Boundary Tests", () => {
     // Should show validation error for buyer address
     await waitFor(() => {
       expect(screen.getByText(/valid stellar public key/i)).toBeInTheDocument();
+    });
+  });
+
+  it("rejects a due date less than 7 days from today", async () => {
+    renderWithProviders(<InvoiceForm />);
+
+    // Enter a valid buyer address
+    const buyerInput = screen.getByPlaceholderText(/stellar public key/i);
+    fireEvent.change(buyerInput, {
+      target: { value: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF" },
+    });
+
+    // Fill a valid face value
+    const faceValueInput = screen.getByPlaceholderText(/50,000\.00/i);
+    fireEvent.change(faceValueInput, { target: { value: "1500" } });
+
+    // Set due date to 3 days from today (below the 7-day minimum)
+    const dateInput = screen.getByTestId("date-picker") as HTMLInputElement;
+    const threeDays = new Date();
+    threeDays.setDate(threeDays.getDate() + 3);
+    fireEvent.change(dateInput, {
+      target: { value: threeDays.toISOString().split("T")[0] },
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /review financing terms/i }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/at least 7 days from today/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("rejects a due date more than 365 days from today", async () => {
+    renderWithProviders(<InvoiceForm />);
+
+    // Enter a valid buyer address
+    const buyerInput = screen.getByPlaceholderText(/stellar public key/i);
+    fireEvent.change(buyerInput, {
+      target: { value: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF" },
+    });
+
+    // Fill a valid face value
+    const faceValueInput = screen.getByPlaceholderText(/50,000\.00/i);
+    fireEvent.change(faceValueInput, { target: { value: "1500" } });
+
+    // Set due date to 400 days from today (above the 365-day maximum)
+    const dateInput = screen.getByTestId("date-picker") as HTMLInputElement;
+    const fourHundredDays = new Date();
+    fourHundredDays.setDate(fourHundredDays.getDate() + 400);
+    fireEvent.change(dateInput, {
+      target: { value: fourHundredDays.toISOString().split("T")[0] },
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /review financing terms/i }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/within 365 days from today/i),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/components/invoice/InvoiceForm.tsx
+++ b/apps/web/components/invoice/InvoiceForm.tsx
@@ -102,6 +102,19 @@ export function InvoiceForm({ onSuccess }: InvoiceFormProps) {
       return;
     }
 
+    const minDate = new Date(today);
+    minDate.setDate(minDate.getDate() + 7);
+    const maxDate = new Date(today);
+    maxDate.setDate(maxDate.getDate() + 365);
+    if (selectedDate.getTime() < minDate.getTime()) {
+      setError("Due date must be at least 7 days from today");
+      return;
+    }
+    if (selectedDate.getTime() > maxDate.getTime()) {
+      setError("Due date must be within 365 days from today");
+      return;
+    }
+
     setStep(2);
   };
 


### PR DESCRIPTION
## Summary
Enforced the documented 7-365 day due-date bounds in `InvoiceForm.tsx`.

Investigation: The smart contract docs (`docs/smart-contracts/invoice-contract.md`) show `invoice_contract.create`'s `due_date` is just a Unix timestamp with no on-chain bound, so option 1 (client-side validation) was chosen to match the documented behavior in `docs/for-smes/create-your-first-invoice.md`.

Changes:
1. **`apps/web/components/invoice/InvoiceForm.tsx`**: Added validation after the existing "must be in the future" check that rejects due dates less than 7 days from today ("Due date must be at least 7 days from today") and more than 365 days from today ("Due date must be within 365 days from today").

2. **`apps/web/components/invoice/InvoiceForm.test.tsx`**: 
   - Updated the `@stellar/stellar-sdk` mock so `isValidEd25519PublicKey` returns `true` for addresses starting with "G" (needed to pass buyer validation in the new boundary tests).
   - Added two new test cases: one rejecting a due date 3 days out (below the 7-day minimum) and one rejecting a due date 400 days out (above the 365-day maximum).

The existing "must be in the future" validation still works for dates inside the window, and the existing invalid-buyer test still passes since buyer validation runs before due-date validation.

## Changed files
- `apps/web/components/invoice/InvoiceForm.test.tsx`
- `apps/web/components/invoice/InvoiceForm.tsx`

## Test plan
1. `pnpm --filter web exec tsc --noEmit` — type-check clean
2. `pnpm --filter web test` — run the InvoiceForm test suite (existing + 2 new boundary tests)
3. `pnpm --filter web lint` — lint clean
4. `pnpm build` — full build succeeds

This PR was created as a draft by the issue solver bot. It will remain a
draft until repository CI passes.

Closes #572
