### PR TITLE
fix: [Easy] docs(protocol): note the attestation requirement in invoice-lifecycle.md's Listed section

### DIFF
--- a/docs/protocol/invoice-lifecycle.md
+++ b/docs/protocol/invoice-lifecycle.md
@@ -29,6 +29,10 @@ The SME sets a discount rate and makes the invoice visible in the marketplace. L
 providers can see and fund it. The discount rate is final — it cannot be changed after
 listing.
 
+Listing requires a stored risk attestation from a registered Underwrite agent (see
+[submit_attestation](../smart-contracts/invoice-contract.md#submit_attestation) for the
+full mechanism). If none exists, the call fails fast with `VerificationRequired`.
+
 ### Funded
 
 Triggered by: `pool_contract.fund_invoice(invoice_id)`  


### PR DESCRIPTION
## Summary
Updated `docs/protocol/invoice-lifecycle.md`'s `### Listed` section to note that listing via `list_for_financing` now requires a stored risk attestation from a registered Underwrite agent, linking to `docs/smart-contracts/invoice-contract.md#submit_attestation` for the full mechanism, and noting that the call fails fast with `VerificationRequired` if none exists. Pure Markdown change; no code modified.

## Changed files
- `docs/protocol/invoice-lifecycle.md`

## Test plan
No code changes were made, so no TypeScript/Go tests are affected. CI jobs (Verify TypeScript Frontend & SDK and Verify Go Indexer & API) should remain green since only a Markdown doc was edited. Local verification: the relative link `../smart-contracts/invoice-contract.md#submit_attestation` resolves to the existing `submit_attestation` section in `docs/smart-contracts/invoice-contract.md`.

This PR was created as a draft by the issue solver bot. It will remain a
draft until repository CI passes.

Closes #571
