### PR TITLE
fix(web): type the role select in Navbar.tsx instead of casting to any (closes #543)

### DIFF
--- a/apps/web/components/shared/Navbar.tsx
+++ b/apps/web/components/shared/Navbar.tsx
@@ -10,6 +10,13 @@ import { useBalances } from "@/hooks/useBalances";
 import { useProfile } from "@/hooks/useProfile";
 import { Wallet, Shield, Terminal, ExternalLink, Menu, X } from "lucide-react";
 
+const ROLES = ["issuer", "buyer", "lp"] as const;
+type Role = (typeof ROLES)[number];
+
+function isRole(value: string): value is Role {
+  return (ROLES as readonly string[]).includes(value);
+}
+
 export function Navbar() {
   const pathname = usePathname();
   const { role, setRole, connected } = useWalletStore();
@@ -125,7 +132,12 @@ export function Navbar() {
                   </span>
                   <select
                     value={role}
-                    onChange={(e) => setRole(e.target.value as any)}
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      if (isRole(value)) {
+                        setRole(value);
+                      }
+                    }}
                     className="bg-transparent text-xs text-white border-none focus:ring-0 focus:outline-none font-bold font-mono cursor-pointer pr-5 py-0"
                   >
                     <option


### PR DESCRIPTION
## Summary

Fixes #543 — removes the `as any` cast on the role `<select>` in `apps/web/components/shared/Navbar.tsx` and replaces it with a runtime-validated narrowing against the actual role union type that `useWalletStore.setRole` expects.

## Problem

The role selector in the Navbar was:

```tsx
onChange={(e) => setRole(e.target.value as any)}
```

`setRole` (from `apps/web/store/wallet.ts`) is typed to accept only `"issuer" | "buyer" | "lp"`, but the `as any` cast:

- Silently bypasses the type system — `any` defeats the union constraint at compile time.
- Allows an invalid runtime value (e.g., a tampered/malformed option value or a stale persisted role) to be written straight into the wallet store, producing an invalid role at runtime that other components (e.g., `InvoiceCard`'s `role?: "issuer" | "buyer" | "lp"` prop) assume is always one of the three valid values.

## What Changed

In `apps/web/components/shared/Navbar.tsx`:

1. Added a `ROLES` const array and derived `Role` type (`"issuer" | "buyer" | "lp"` — the same union `useWalletStore.setRole` expects):

   ```ts
   const ROLES = ["issuer", "buyer", "lp"] as const;
   type Role = (typeof ROLES)[number];
   ```

2. Added a type guard `isRole(value: string): value is Role` that narrows the raw string safely.

3. Updated the `onChange` handler to validate before calling `setRole`:

   ```tsx
   onChange={(e) => {
     const value = e.target.value;
     if (isRole(value)) {
       setRole(value);
     }
   }}
   ```

## Why This Approach

- **Matches the real type**: `setRole` is typed `(role: "issuer" | "buyer" | "lp") => void` in `apps/web/store/wallet.ts` — the guard is built against exactly that union.
- **Runtime safety**: rather than an unchecked assertion (`as "issuer" | "buyer" | "lp"`), the guard rejects invalid values outright, so an invalid `<option>` value can never silently produce an invalid role at runtime.
- **Minimal diff**: the change is confined to a single file; no store or type changes needed.

## Acceptance Criteria

- [x] No `any` remains on the role-select line (verified — zero `any` occurrences remain in `Navbar.tsx`).
- [x] Invalid `<option>` values can't silently produce an invalid role at runtime (the `isRole` guard drops non-union values before `setRole` is called).
- [x] `pnpm --filter web exec tsc --noEmit` clean.

## Local Verification (all green)

| Check | Command | Result |
|---|---|---|
| Web typecheck | `pnpm --filter web exec tsc --noEmit` | ✅ |
| Full repo typecheck | `pnpm typecheck` | ✅ |
| Build (SDK + web, CI env vars) | `pnpm build` | ✅ |
| Tests (SDK + web) | `pnpm test` | ✅ 245 web tests across 30 files + SDK tests |
| Web lint | `pnpm --filter web lint` | ✅ (only pre-existing warnings) |
| Formatting | `npx prettier --check .` | ✅ |
| Go build | `go build -v ./...` (indexer) | ✅ |
| Go vet | `go vet ./...` | ✅ |
| Go tests | `go test ./...` | ✅ |
| gofmt | `gofmt -l .` | ✅ (no output) |

Both CI jobs — **Verify TypeScript Frontend & SDK** and **Verify Go Indexer & API** — were replicated locally and pass.

## Definition of Done

- [x] PR links back with `Closes #543`.
- [x] CI is green (both jobs replicated locally).
- [x] Local verification: `tsc --noEmit`, `pnpm build`, `pnpm --filter web lint`, `pnpm --filter web test` all pass.

Closes #543