### PR TITLE
docs(sdk): add JSDoc to InvoiceClient write methods (closes #527)

### DIFF
--- a/packages/sdk/src/clients/invoice.ts
+++ b/packages/sdk/src/clients/invoice.ts
@@ -9,6 +9,16 @@ import { Invoice, InvoiceStatus } from "../types/index.js";
 import { parseInvoice } from "../types/schemas.js";
 
 export class InvoiceClient extends BaseContractClient {
+  /**
+   * Initializes the invoice contract with its admin address.
+   * Side effect: stores the admin address on-chain. Can only be called once —
+   * a second call panics.
+   *
+   * @param adminAddress - The Stellar address to set as the contract admin.
+   * @param signerPublicKey - The Stellar public key that will sign the transaction. Must be the deployer/admin.
+   * @returns The transaction hash of the on-chain submission.
+   * @throws If the contract is already initialized, the transaction simulation fails, or on-chain submission errors.
+   */
   async initialize(
     adminAddress: string,
     signerPublicKey: string,
@@ -17,6 +27,19 @@ export class InvoiceClient extends BaseContractClient {
     return this.writeContract("initialize", args, signerPublicKey);
   }
 
+  /**
+   * Creates a new invoice on-chain in `Created` status.
+   * Side effect: stores the invoice record and emits an event consumed by the indexer.
+   * Both `issuer` and `buyer` must be registered in the registry contract.
+   *
+   * @param issuer - The Stellar address of the invoice issuer (SME). Must match `signerPublicKey` — `issuer.require_auth()` is enforced on-chain.
+   * @param buyer - The Stellar address of the invoice buyer.
+   * @param faceValue - The invoice face value in USDC stroops (1 USDC = 10,000,000 stroops).
+   * @param dueDate - The invoice due date as a Unix timestamp in seconds.
+   * @param signerPublicKey - The Stellar public key that will sign the transaction. Must be the invoice issuer.
+   * @returns The transaction hash of the on-chain submission.
+   * @throws If `issuer` or `buyer` is not registered in the registry contract, the transaction simulation fails, or on-chain submission errors.
+   */
   async create(
     issuer: string,
     buyer: string,
@@ -57,6 +80,15 @@ export class InvoiceClient extends BaseContractClient {
     );
   }
 
+  /**
+   * Marks an invoice as shipped on-chain.
+   * Side effect: the invoice status transitions to `Active`.
+   *
+   * @param invoiceIdHex - The invoice ID as a 32-byte hex string.
+   * @param signerPublicKey - The Stellar public key that will sign the transaction. Must be the invoice issuer.
+   * @returns `true` when the transaction succeeds on-chain.
+   * @throws If the transaction simulation fails or the on-chain submission errors.
+   */
   async markShipped(
     invoiceIdHex: string,
     signerPublicKey: string,
@@ -105,6 +137,16 @@ export class InvoiceClient extends BaseContractClient {
     return this.writeContract("repay", args, signerPublicKey).then(() => true);
   }
 
+  /**
+   * Triggers a default on an overdue invoice on-chain.
+   * Side effect: the invoice status transitions to `Defaulted` and `pool_contract.handle_default()` is invoked.
+   * Only callable by the contract admin or the pool contract, and only after the invoice's due date has passed.
+   *
+   * @param invoiceIdHex - The invoice ID as a 32-byte hex string.
+   * @param signerPublicKey - The Stellar public key that will sign the transaction. Must be the contract admin.
+   * @returns `true` when the transaction succeeds on-chain.
+   * @throws If the invoice is not in `Funded`, `Active`, or `Confirmed` status, its due date has not passed, the transaction simulation fails, or on-chain submission errors.
+   */
   async triggerDefault(
     invoiceIdHex: string,
     signerPublicKey: string,


### PR DESCRIPTION
## Summary

Fixes #527 — completes JSDoc coverage on `InvoiceClient`'s write methods in `packages/sdk/src/clients/invoice.ts`. The four methods missing documentation — `initialize`, `create`, `markShipped`, and `triggerDefault` — now carry JSDoc blocks matching the style already used on the file's other documented methods (`listForFinancing`, `confirmDelivery`, `repay`, `get`) and on `RegistryClient.registerBuyer`/`revoke`.

Documentation only — **no behavior change**.

## Problem

Public SDK methods are meant to carry JSDoc naming params and describing the return value / side effects (see the completed JSDoc passes on `invoice.ts`'s and `registry.ts`'s other methods). The four write methods above had no `/** ... */` block, so callers got no inline documentation of params, return value, or thrown errors.

## What Changed

Added a JSDoc block above each of the four methods in `packages/sdk/src/clients/invoice.ts`:

| Method | Contract fn | Documented semantics (from `docs/smart-contracts/`) |
|---|---|---|
| `initialize` | `initialize` | Sets the contract admin address; can only be called once — a second call panics. Returns the transaction hash. |
| `create` | `create` | Creates an invoice in `Created` status. `faceValue` is in USDC stroops (1 USDC = 10,000,000), `dueDate` is a Unix timestamp in seconds. Both `issuer` and `buyer` must be registered in `registry_contract`; `issuer.require_auth()` enforced on-chain. Returns the transaction hash. |
| `markShipped` | `mark_shipped` | Issuer confirms goods shipped; status transitions to `Active`. Returns `true` on success. |
| `triggerDefault` | `trigger_default` | Callable by the contract admin or the pool contract after the due date; invoice must be in `Funded`, `Active`, or `Confirmed` status; invokes `pool_contract.handle_default()`; status transitions to `Defaulted`. Returns `true` on success. |

Each block follows the existing file conventions:

- `@param` for every parameter (naming units for `faceValue`/`dueDate`, hex format for `invoiceIdHex`)
- `@returns` describing the actual SDK return value (`Promise<string>` methods return the on-chain transaction hash, `Promise<boolean>` methods return `true` on success — verified against `writeContract` in `base.ts`)
- `@throws` covering both simulation/on-chain submission failures and contract-specific panics (e.g., already-initialized, unregistered parties, invalid invoice status/due date)
- Auth/permission requirements and on-chain side effects called out explicitly, per the issue's request and the `registerBuyer`/`listForFinancing` precedent

## Why This Approach

- **Accuracy**: semantics were pulled from the smart-contract reference in `docs/smart-contracts/invoice-contract.md` (and `registry-contract.md` for the `initialize` once-only rule) rather than inferred.
- **Consistency**: matches the `@param`/`@returns`/`@throws` + "Side effect:" style already used throughout the file.
- **No runtime risk**: pure documentation — zero behavioral changes, so no new test coverage is required.

## Acceptance Criteria

- [x] Every method listed above (`initialize`, `create`, `markShipped`, `triggerDefault`) has a JSDoc block with `@param`/`@returns`.
- [x] Side effects and auth requirements are called out where relevant (on-chain side-effect lines + `require_auth`/admin notes).
- [x] No behavior change — documentation only (diff is +42 lines, comments only).

## Local Verification (all green)

| Check | Command | Result |
|---|---|---|
| SDK build | `pnpm --filter @trusttrove/sdk build` | ✅ |
| SDK tests | `pnpm --filter @trusttrove/sdk test` | ✅ 76 tests / 13 files |
| Full repo typecheck | `pnpm typecheck` | ✅ |
| Build (SDK + web, CI env vars) | `pnpm build` | ✅ |
| Full tests (SDK + web) | `pnpm test` | ✅ 76 SDK + 245 web tests |
| Web lint | `pnpm --filter web lint` | ✅ (pre-existing warnings only) |
| Formatting | `npx prettier --check .` | ✅ |
| Go build / vet / test / gofmt | `indexer` | ✅ all pass |

Both CI jobs — **Verify TypeScript Frontend & SDK** and **Verify Go Indexer & API** — were replicated locally and pass. (Note: `test/initialize.test.js` uses the `node:test` API and reports "no test suite found" under vitest — this is pre-existing on `main` and does not fail the CI command; verified identical behavior on a clean `upstream/main` checkout.)

## Definition of Done

- [x] PR links back with `Closes #527`.
- [x] CI is green (both jobs replicated locally).
- [x] Local verification: SDK build and tests green.

Closes #527