### PR TITLE
fix(web): type SimulationPreview expectedResult with SimulationResult from SDK

### DIFF
--- a/apps/web/components/shared/SimulationPreview.tsx
+++ b/apps/web/components/shared/SimulationPreview.tsx
@@ -1,15 +1,9 @@
 import React from "react";
 import { Cpu, Coins, ShieldAlert, Sparkles } from "lucide-react";
-
-interface SimulationDetails {
-  estimatedFeeXlm: string;
-  functionName: string;
-  expectedResult: any;
-  footprintSize: number;
-}
+import type { SimulationResult } from "@trusttrove/sdk";
 
 interface SimulationPreviewProps {
-  details: SimulationDetails | null;
+  details: SimulationResult | null;
   error: string | null;
   isLoading: boolean;
   isFallback?: boolean;

--- a/packages/sdk/src/base.ts
+++ b/packages/sdk/src/base.ts
@@ -65,6 +65,13 @@ const signTransactionCompat = signTransactionFn as (
 
 const MAX_TRANSACTION_POLL_ATTEMPTS = 30;
 
+export interface SimulationResult {
+  estimatedFeeXlm: string;
+  functionName: string;
+  expectedResult: unknown;
+  footprintSize: number;
+}
+
 export class TransactionTimeoutError extends Error {
   readonly txHash: string;
 
@@ -241,12 +248,7 @@ export class BaseContractClient {
     method: string,
     args: xdr.ScVal[],
     publicKey: string,
-  ): Promise<{
-    estimatedFeeXlm: string;
-    functionName: string;
-    expectedResult: any;
-    footprintSize: number;
-  }> {
+  ): Promise<SimulationResult> {
     const config = getConfig();
     const server = getSorobanServer();
     const account = await withRetry(() => server.getAccount(publicKey));
@@ -270,7 +272,7 @@ export class BaseContractClient {
       : 0;
 
     const retval = sim.result?.retval;
-    let expectedResult: any = undefined;
+    let expectedResult: unknown = undefined;
     if (retval) {
       try {
         expectedResult = scValToNative(retval);


### PR DESCRIPTION
## Summary

Replaces `expectedResult: any` in `SimulationPreview`'s props with a proper `SimulationResult` interface exported from the SDK.

## Changes

- **`packages/sdk/src/base.ts`**: Export new `SimulationResult` interface; update `simulateTransaction` return type to use it; change local `expectedResult` variable from `any` to `unknown`.
- **`apps/web/components/shared/SimulationPreview.tsx`**: Import `SimulationResult` from `@trusttrove/sdk` and use it for the `details` prop, replacing the inline `SimulationDetails` interface that had `expectedResult: any`.

## Verification

- [x] `pnpm --filter @trusttrove/sdk build` — clean
- [x] `pnpm --filter web exec tsc --noEmit` — no new errors (pre-existing test-only errors unrelated to this change)
- [x] `pnpm --filter web lint` — clean (pre-existing warnings only)
- [x] `pnpm --filter web test` — 52/52 passed
- [x] `pnpm build` — succeeds

Closes #544