### PR TITLE
Add JSDoc Documentation to Parser Functions

### DIFF
--- a/apps/web/lib/parsers.ts
+++ b/apps/web/lib/parsers.ts
@@ -88,6 +88,62 @@ function extraFields(raw: RawInvoice) {
   };
 }
 
+/**
+ * Parses a raw invoice payload (e.g. a Soroban contract response or an API
+ * JSON object) into a fully-typed {@link Invoice}.
+ *
+ * The raw value may use either `snake_case` or `camelCase` keys. Keys are
+ * first normalized to `camelCase`, then validated against the shared SDK
+ * `invoiceSchema`. When validation succeeds the schema output is used;
+ * otherwise the payload is coerced manually via `manuallyParse`. A set of
+ * extra, optional bookkeeping fields (timestamps and transaction hashes) is
+ * merged on top of the base invoice.
+ *
+ * @param raw - The untrusted payload to parse. Accepts `snake_case` or
+ *   `camelCase` records, or any other value.
+ * @returns An {@link Invoice} augmented with the following extra fields:
+ *   - `listedAt` — `number | null` — Unix timestamp when listed, or `null`.
+ *   - `issuerConfirmedAt` — `number | null` — Unix timestamp of issuer
+ *     confirmation, or `null`.
+ *   - `buyerConfirmedAt` — `number | null` — Unix timestamp of buyer
+ *     confirmation, or `null`.
+ *   - `defaultedAt` — `number | null` — Unix timestamp of default, or `null`.
+ *   - `transactionHashes` — `unknown` — Raw `transaction_hashes` value.
+ *   - `txHashes` — `unknown` — Raw `tx_hashes` value.
+ *   - `createdTxHash` — `unknown` — Hash of the create transaction.
+ *   - `listedTxHash` — `unknown` — Hash of the list transaction.
+ *   - `fundedTxHash` — `unknown` — Hash of the fund transaction.
+ *   - `shippedTxHash` — `unknown` — Hash of the ship transaction.
+ *   - `issuerConfirmedTxHash` — `unknown` — Hash of issuer-confirm transaction.
+ *   - `buyerConfirmedTxHash` — `unknown` — Hash of buyer-confirm transaction.
+ *   - `repaidTxHash` — `unknown` — Hash of the repay transaction.
+ *   - `defaultedTxHash` — `unknown` — Hash of the default transaction.
+ *
+ *   The base {@link Invoice} fields are:
+ *   - `id` — `string` — hex string of the invoice `BytesN<32>` identifier.
+ *   - `issuer` — `string` — Issuer account address.
+ *   - `buyer` — `string` — Buyer account address.
+ *   - `faceValue` — `bigint` — u128 amount in stroops (10^7 = 1 unit).
+ *   - `asset` — `AssetType` — Denominated asset (`'USDC'` or `'XLM'`).
+ *   - `discountBps` — `number` — u32 discount in basis points.
+ *   - `fundedAmount` — `bigint` — u128 funded amount in stroops.
+ *   - `dueDate` — `number` — Unix timestamp of the due date.
+ *   - `status` — `InvoiceStatus` — Lifecycle status of the invoice.
+ *   - `createdAt` — `number` — Unix timestamp of creation.
+ *   - `fundedAt` — `number | null` — Unix timestamp of funding, or `null`.
+ *   - `shippedAt` — `number | null` — Unix timestamp of shipping, or `null`.
+ *   - `issuerConfirmed` — `boolean` — Whether the issuer confirmed.
+ *   - `buyerConfirmed` — `boolean` — Whether the buyer confirmed.
+ *   - `repaidAt` — `number | null` — Unix timestamp of repayment, or `null`.
+ *
+ * @throws `Error('Invalid invoice payload')` when `raw` is not a record.
+ *
+ * @example
+ * ```ts
+ * const invoice = parseInvoiceResponse(contractResult);
+ * console.log(invoice.id, invoice.faceValue, invoice.status);
+ * ```
+ */
 export function parseInvoiceResponse(raw: unknown): Invoice {
   if (!isRecord(raw)) {
     throw new Error("Invalid invoice payload");


### PR DESCRIPTION
##closed #539 

Add comprehensive JSDoc documentation to the exported functions in apps/web/lib/parsers.ts, following the existing documentation style used by hooks such as useProfile.ts and useTokenAllowance.ts.

The documentation should describe each function's parameters, the returned object's shape and individual fields, and include @example sections where useful. This is a documentation-only change and must not modify the existing parser behavior.

The implementation should also maintain the project's existing TypeScript, linting, build, and test standards.