### PR TITLE
docs(web): add JSDoc to config.ts helpers

### DIFF
--- a/apps/web/components/shared/SkeletonLoader.test.tsx
+++ b/apps/web/components/shared/SkeletonLoader.test.tsx
@@ -13,34 +13,42 @@ import {
 
 describe("SkeletonLoader", () => {
   it("renders the shimmer element with the provided className", () => {
-    const { container } = render(
-      <SkeletonShimmer className="h-4 w-32" />,
-    );
+    const { container } = render(<SkeletonShimmer className="h-4 w-32" />);
 
     const shimmer = container.firstChild as HTMLElement;
     expect(shimmer).toBeInTheDocument();
     expect(shimmer).toHaveClass("h-4", "w-32");
-    expect(shimmer.querySelector(".animate-\\[shimmer_1\\.5s_infinite\\]")).toBeTruthy();
+    expect(
+      shimmer.querySelector(".animate-\\[shimmer_1\\.5s_infinite\\]"),
+    ).toBeTruthy();
   });
 
   it("renders InvoiceCardSkeleton with its shimmer blocks", () => {
     const { container } = render(<InvoiceCardSkeleton />);
 
     expect(container.firstChild).toBeInTheDocument();
-    expect(container.querySelectorAll(".animate-\\[shimmer_1\\.5s_infinite\\]").length).toBeGreaterThan(0);
+    expect(
+      container.querySelectorAll(".animate-\\[shimmer_1\\.5s_infinite\\]")
+        .length,
+    ).toBeGreaterThan(0);
   });
 
   it("renders PoolStatsPanelSkeleton with four stat placeholders", () => {
     const { container } = render(<PoolStatsPanelSkeleton />);
 
     expect(container.firstChild).toBeInTheDocument();
-    expect(container.querySelectorAll(".animate-\\[shimmer_1\\.5s_infinite\\]").length).toBeGreaterThanOrEqual(4);
+    expect(
+      container.querySelectorAll(".animate-\\[shimmer_1\\.5s_infinite\\]")
+        .length,
+    ).toBeGreaterThanOrEqual(4);
   });
 
   it("renders InvoiceFeedSkeleton with three feed rows", () => {
     const { container } = render(<InvoiceFeedSkeleton />);
 
-    expect(container.querySelectorAll('[class*="rounded"]').length).toBeGreaterThan(0);
+    expect(
+      container.querySelectorAll('[class*="rounded"]').length,
+    ).toBeGreaterThan(0);
     expect(container.firstChild).toBeInTheDocument();
   });
 
@@ -55,13 +63,19 @@ describe("SkeletonLoader", () => {
     const { container } = render(<LPPositionCardSkeleton />);
 
     expect(container.firstChild).toBeInTheDocument();
-    expect(container.querySelectorAll(".animate-\\[shimmer_1\\.5s_infinite\\]").length).toBeGreaterThan(0);
+    expect(
+      container.querySelectorAll(".animate-\\[shimmer_1\\.5s_infinite\\]")
+        .length,
+    ).toBeGreaterThan(0);
   });
 
   it("renders ActivityTimelineSkeleton with five timeline placeholders", () => {
     const { container } = render(<ActivityTimelineSkeleton />);
 
     expect(container.firstChild).toBeInTheDocument();
-    expect(container.querySelectorAll(".animate-\\[shimmer_1\\.5s_infinite\\]").length).toBeGreaterThanOrEqual(5);
+    expect(
+      container.querySelectorAll(".animate-\\[shimmer_1\\.5s_infinite\\]")
+        .length,
+    ).toBeGreaterThanOrEqual(5);
   });
 });

--- a/apps/web/lib/config.ts
+++ b/apps/web/lib/config.ts
@@ -4,6 +4,12 @@ const REQUIRED_ENV_VARS = [
   "NEXT_PUBLIC_REGISTRY_CONTRACT_ID",
 ] as const;
 
+/**
+ * Result of validating the required environment variables.
+ *
+ * @property missing - Names of required env vars that are absent or empty.
+ * @property isConfigured - `true` when every required env var is present.
+ */
 export interface ConfigValidation {
   missing: string[];
   isConfigured: boolean;
@@ -11,6 +17,26 @@ export interface ConfigValidation {
 
 let cachedValidation: ConfigValidation | null = null;
 
+/**
+ * Validates that all required environment variables are set.
+ *
+ * Checks for `NEXT_PUBLIC_INVOICE_CONTRACT_ID`,
+ * `NEXT_PUBLIC_POOL_CONTRACT_ID`, and `NEXT_PUBLIC_REGISTRY_CONTRACT_ID`.
+ * Logs a console warning listing any missing variables and caches the result
+ * so subsequent calls are free.
+ *
+ * @returns A {@link ConfigValidation} object describing the current state:
+ *   - `missing` — array of env-var names that are absent or empty.
+ *   - `isConfigured` — `true` when every required var is present.
+ *
+ * @example
+ * ```ts
+ * const { isConfigured, missing } = validateConfig();
+ * if (!isConfigured) {
+ *   console.error("Missing env vars:", missing);
+ * }
+ * ```
+ */
 export function validateConfig(): ConfigValidation {
   if (cachedValidation) return cachedValidation;
 


### PR DESCRIPTION
## Summary

Adds JSDoc blocks to the exported  function and  interface in , matching the style used in  and .

## Changes

- ** interface** —  tags for  and .
- ** function** — description of purpose, which env vars are checked, caching behaviour,  with  to the interface, and an  snippet.

No behavior change — documentation only.

## Verification

- `pnpm --filter web exec tsc --noEmit` — 0 errors
- `pnpm --filter web lint` — clean
- `pnpm --filter web test` — 252 tests passed

Closes #536