### PR TITLE
test(web): add unit test file for ConfigBanner

### DIFF
--- a/apps/web/components/shared/ConfigBanner.test.tsx
+++ b/apps/web/components/shared/ConfigBanner.test.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ConfigBanner } from "./ConfigBanner";
+import { validateConfig } from "@/lib/config";
+
+vi.mock("@/lib/config", () => ({
+  validateConfig: vi.fn(),
+}));
+
+describe("ConfigBanner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when all required env vars are configured", () => {
+    vi.mocked(validateConfig).mockReturnValue({
+      missing: [],
+      isConfigured: true,
+    });
+
+    const { container } = render(<ConfigBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders banner with missing env var labels", () => {
+    vi.mocked(validateConfig).mockReturnValue({
+      missing: [
+        "NEXT_PUBLIC_INVOICE_CONTRACT_ID",
+        "NEXT_PUBLIC_POOL_CONTRACT_ID",
+      ],
+      isConfigured: false,
+    });
+
+    render(<ConfigBanner />);
+
+    expect(screen.getByText("Configuration Error")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Missing required environment variables/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Invoice Contract, Pool Contract/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(".env.local")).toBeInTheDocument();
+  });
+
+  it("falls back to raw key name for unknown env vars", () => {
+    vi.mocked(validateConfig).mockReturnValue({
+      missing: ["NEXT_PUBLIC_UNKNOWN_CONTRACT_ID"],
+      isConfigured: false,
+    });
+
+    render(<ConfigBanner />);
+
+    expect(
+      screen.getByText(/NEXT_PUBLIC_UNKNOWN_CONTRACT_ID/),
+    ).toBeInTheDocument();
+  });
+
+  it("lists all three required env vars when all are missing", () => {
+    vi.mocked(validateConfig).mockReturnValue({
+      missing: [
+        "NEXT_PUBLIC_INVOICE_CONTRACT_ID",
+        "NEXT_PUBLIC_POOL_CONTRACT_ID",
+        "NEXT_PUBLIC_REGISTRY_CONTRACT_ID",
+      ],
+      isConfigured: false,
+    });
+
+    render(<ConfigBanner />);
+
+    expect(
+      screen.getByText(/Invoice Contract, Pool Contract, Registry Contract/),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/shared/SkeletonLoader.test.tsx
+++ b/apps/web/components/shared/SkeletonLoader.test.tsx
@@ -13,34 +13,42 @@ import {
 
 describe("SkeletonLoader", () => {
   it("renders the shimmer element with the provided className", () => {
-    const { container } = render(
-      <SkeletonShimmer className="h-4 w-32" />,
-    );
+    const { container } = render(<SkeletonShimmer className="h-4 w-32" />);
 
     const shimmer = container.firstChild as HTMLElement;
     expect(shimmer).toBeInTheDocument();
     expect(shimmer).toHaveClass("h-4", "w-32");
-    expect(shimmer.querySelector(".animate-\\[shimmer_1\\.5s_infinite\\]")).toBeTruthy();
+    expect(
+      shimmer.querySelector(".animate-\\[shimmer_1\\.5s_infinite\\]"),
+    ).toBeTruthy();
   });
 
   it("renders InvoiceCardSkeleton with its shimmer blocks", () => {
     const { container } = render(<InvoiceCardSkeleton />);
 
     expect(container.firstChild).toBeInTheDocument();
-    expect(container.querySelectorAll(".animate-\\[shimmer_1\\.5s_infinite\\]").length).toBeGreaterThan(0);
+    expect(
+      container.querySelectorAll(".animate-\\[shimmer_1\\.5s_infinite\\]")
+        .length,
+    ).toBeGreaterThan(0);
   });
 
   it("renders PoolStatsPanelSkeleton with four stat placeholders", () => {
     const { container } = render(<PoolStatsPanelSkeleton />);
 
     expect(container.firstChild).toBeInTheDocument();
-    expect(container.querySelectorAll(".animate-\\[shimmer_1\\.5s_infinite\\]").length).toBeGreaterThanOrEqual(4);
+    expect(
+      container.querySelectorAll(".animate-\\[shimmer_1\\.5s_infinite\\]")
+        .length,
+    ).toBeGreaterThanOrEqual(4);
   });
 
   it("renders InvoiceFeedSkeleton with three feed rows", () => {
     const { container } = render(<InvoiceFeedSkeleton />);
 
-    expect(container.querySelectorAll('[class*="rounded"]').length).toBeGreaterThan(0);
+    expect(
+      container.querySelectorAll('[class*="rounded"]').length,
+    ).toBeGreaterThan(0);
     expect(container.firstChild).toBeInTheDocument();
   });
 
@@ -55,13 +63,19 @@ describe("SkeletonLoader", () => {
     const { container } = render(<LPPositionCardSkeleton />);
 
     expect(container.firstChild).toBeInTheDocument();
-    expect(container.querySelectorAll(".animate-\\[shimmer_1\\.5s_infinite\\]").length).toBeGreaterThan(0);
+    expect(
+      container.querySelectorAll(".animate-\\[shimmer_1\\.5s_infinite\\]")
+        .length,
+    ).toBeGreaterThan(0);
   });
 
   it("renders ActivityTimelineSkeleton with five timeline placeholders", () => {
     const { container } = render(<ActivityTimelineSkeleton />);
 
     expect(container.firstChild).toBeInTheDocument();
-    expect(container.querySelectorAll(".animate-\\[shimmer_1\\.5s_infinite\\]").length).toBeGreaterThanOrEqual(5);
+    expect(
+      container.querySelectorAll(".animate-\\[shimmer_1\\.5s_infinite\\]")
+        .length,
+    ).toBeGreaterThanOrEqual(5);
   });
 });


### PR DESCRIPTION
Closes #504

Adds a colocated test file for `ConfigBanner` covering:

1. **Default render** – renders nothing when all required env vars are configured (`isConfigured: true`).
2. **Missing env vars** – renders the warning banner with human-readable labels for known missing vars.
3. **Unknown env var** – falls back to displaying the raw key name for unrecognized env var keys.
4. **All missing** – lists all three required env vars when all are missing.

Verified locally:
- `pnpm --filter web exec tsc --noEmit` clean
- `pnpm --filter web lint` clean
- `pnpm --filter web test` green (32 test files, 256 tests)