### PR TITLE
fix(web): narrow renderStat error parameter

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -52,7 +52,14 @@ export default function Home() {
     if (isLoading) {
       return <SkeletonShimmer className="h-7 w-20 mx-auto lg:mx-0" />;
     }
-    if (error || value === null) {
+
+    const errorMessage =
+      error instanceof Error
+        ? error.message
+        : error == null
+          ? null
+          : "An unexpected error occurred.";
+    if (errorMessage !== null || value === null) {
       return (
         <span className="text-xl sm:text-2xl font-bold font-mono text-slate-600 block">
           —

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -47,7 +47,7 @@ export default function Home() {
   const renderStat = (
     value: string | null,
     isLoading?: boolean,
-    error?: any,
+    error?: unknown,
   ) => {
     if (isLoading) {
       return <SkeletonShimmer className="h-7 w-20 mx-auto lg:mx-0" />;


### PR DESCRIPTION
## Summary

- Replace the `renderStat` helper's `error?: any` parameter with `error?: unknown`.
- Preserve the existing fallback behavior for error values without introducing unsafe property access.

## Validation

- `pnpm --filter web exec tsc --noEmit` ✅
- `pnpm --filter web test` ✅ — 31 test files, 252 tests passed
- `pnpm --filter web lint` ✅ — existing unrelated warnings remain
- `pnpm build` ✅ with the documented public testnet environment variables

The initial build without environment variables failed during prerendering because the local environment did not define the required contract IDs; rerunning with the values from the repository's environment template completed successfully. Existing lint and bundler warnings are unrelated to this change.

Closes #541