### PR TITLE
test(web): add InvoiceStatusTimeline coverage

### DIFF
--- a/apps/web/components/invoice/InvoiceStatusTimeline.test.tsx
+++ b/apps/web/components/invoice/InvoiceStatusTimeline.test.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { InvoiceStatusTimeline } from "./InvoiceStatusTimeline";
+import type { Invoice } from "@/types";
+
+const issuer = "GACR43ILX6H4PGAOO5QKSZLU4ZJMGT3E66EAUDPLM5J6YTP4Y3PSHWGB";
+const buyer = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+
+const makeInvoice = (overrides: Partial<Invoice> = {}): Invoice => ({
+  id: "invoice-1",
+  status: "Created",
+  issuer,
+  buyer,
+  faceValue: 1_000_000_000n,
+  asset: "USDC",
+  discountBps: 500,
+  fundedAmount: 0n,
+  dueDate: 1_735_689_600,
+  createdAt: 1_735_430_400,
+  fundedAt: null,
+  shippedAt: null,
+  issuerConfirmed: false,
+  buyerConfirmed: false,
+  repaidAt: null,
+  ...overrides,
+});
+
+describe("InvoiceStatusTimeline", () => {
+  it("renders every timeline step and marks future steps as pending", () => {
+    render(<InvoiceStatusTimeline invoice={makeInvoice()} />);
+
+    expect(screen.getByText("Created")).toBeInTheDocument();
+    expect(screen.getByText("Listed for Financing")).toBeInTheDocument();
+    expect(screen.getByText("Funded by Pool")).toBeInTheDocument();
+    expect(screen.getByText("Marked as Shipped")).toBeInTheDocument();
+    expect(screen.getByText("Delivery Confirmed - Issuer")).toBeInTheDocument();
+    expect(screen.getByText("Delivery Confirmed - Buyer")).toBeInTheDocument();
+    expect(screen.getByText("Repaid / Defaulted")).toBeInTheDocument();
+    expect(screen.getAllByText("Pending")).toHaveLength(6);
+  });
+
+  it("advances the timeline and displays the repaid settlement state", () => {
+    render(
+      <InvoiceStatusTimeline
+        invoice={makeInvoice({
+          status: "Repaid",
+          fundedAt: 1_735_500_000,
+          shippedAt: 1_735_550_000,
+          buyerConfirmed: true,
+          buyerConfirmedAt: 1_735_600_000,
+          repaidAt: 1_735_650_000,
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Repaid")).toBeInTheDocument();
+    expect(screen.queryByText("Repaid / Defaulted")).not.toBeInTheDocument();
+    expect(screen.getAllByText(/Dec/).length).toBeGreaterThan(0);
+  });
+
+  it("renders transaction hash links for mapped and legacy transaction fields", () => {
+    render(
+      <InvoiceStatusTimeline
+        invoice={makeInvoice({
+          status: "Active",
+          ...({
+            createdTxHash: "created-transaction-hash",
+            transactionHashes: { shipped: "shipped-transaction-hash" },
+          } as Partial<Invoice>),
+        })}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: /created-/i })).toHaveAttribute(
+      "href",
+      "https://stellar.expert/explorer/testnet/tx/created-transaction-hash",
+    );
+    expect(screen.getByRole("link", { name: /shipped-/i })).toHaveAttribute(
+      "href",
+      "https://stellar.expert/explorer/testnet/tx/shipped-transaction-hash",
+    );
+    expect(screen.getAllByText("No tx hash recorded")).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
## Summary

- Add the missing colocated `InvoiceStatusTimeline.test.tsx` unit test file.
- Cover the default Created state and all rendered timeline labels.
- Cover progression to Repaid with timestamps and settlement labeling.
- Cover transaction hash links from both direct and mapped metadata fields.

## Scope

Tests only. The `InvoiceStatusTimeline` implementation was not changed.

## Validation

- `pnpm --filter web exec tsc --noEmit` ✅
- `pnpm --filter web test` ✅ — 33 test files, 259 tests passed
- `npx prettier --check apps/web/components/invoice/InvoiceStatusTimeline.test.tsx` ✅

Closes #502