### PR TITLE
docs(sdk): add JSDoc to EscrowClient initialize and lock (closes #524)

### DIFF
--- a/packages/sdk/src/clients/escrow.ts
+++ b/packages/sdk/src/clients/escrow.ts
@@ -7,6 +7,16 @@ import {
 import { BaseContractClient } from "../base.js";
 
 export class EscrowClient extends BaseContractClient {
+  /**
+   * Initializes the escrow contract with its admin address.
+   * Side effect: stores the admin address on-chain. Can only be called once —
+   * a second call panics.
+   *
+   * @param adminAddress - The Stellar address to set as the contract admin.
+   * @param signerPublicKey - The Stellar public key that will sign the transaction. Must be the deployer/admin.
+   * @returns The transaction hash of the on-chain submission.
+   * @throws If the contract is already initialized, the transaction simulation fails, or on-chain submission errors.
+   */
   async initialize(
     adminAddress: string,
     signerPublicKey: string,
@@ -15,6 +25,18 @@ export class EscrowClient extends BaseContractClient {
     return this.writeContract("initialize", args, signerPublicKey);
   }
 
+  /**
+   * Locks USDC for an invoice by transferring funds from the pool to the escrow contract.
+   * Side effect: transfers `amount` USDC from `pool_contract` to the escrow contract and
+   * creates an `EscrowRecord` for the invoice. `pool_contract.require_auth()` is enforced —
+   * only the pool contract can call this.
+   *
+   * @param invoiceIdHex - The invoice ID as a 32-byte hex string.
+   * @param amount - The USDC amount to lock, in stroops (1 USDC = 10,000,000 stroops).
+   * @param signerPublicKey - The Stellar public key that will sign the transaction. Must be the pool contract.
+   * @returns `true` when the transaction succeeds on-chain.
+   * @throws If the transaction simulation fails or the on-chain submission errors.
+   */
   async lock(
     invoiceIdHex: string,
     amount: bigint,


### PR DESCRIPTION
## Summary
- Adds JSDoc coverage to the two undocumented EscrowClient methods: `initialize` and `lock`.

## Changes
- Document `initialize` with admin address param, transaction-hash return, one-time initialization side effect, and deployer/admin auth requirement.
- Document `lock` with invoice ID and stroop amount params, boolean return, pool-to-escrow transfer side effect (creates `EscrowRecord`), and `pool_contract.require_auth()` requirement.
- Documentation only — no logic, signatures, or other files changed.

## Testing
- `pnpm --filter @trusttrove/sdk build` passes
- `pnpm --filter @trusttrove/sdk test` passes (76 tests)
- `git diff --check` clean

Closes #524