### PR TITLE
Trus trove app3

### DIFF
--- a/apps/web/app/invoice/[invoiceId]/InvoiceDetailClient.test.tsx
+++ b/apps/web/app/invoice/[invoiceId]/InvoiceDetailClient.test.tsx
@@ -1,0 +1,398 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import InvoiceDetailClient from "./InvoiceDetailClient";
+import { useInvoice, useInvoices } from "@/hooks/useInvoices";
+import { useWalletStore } from "@/store/wallet";
+import { useRouter } from "next/navigation";
+import type { Invoice } from "@/types";
+
+// next/navigation's useRouter throws outside of an App Router provider.
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(),
+  usePathname: vi.fn(() => "/invoice/abc"),
+}));
+
+// Keep the page-level shell out of these tests so they exercise
+// InvoiceDetailClient's own rendering and interactions in isolation.
+vi.mock("@/components/shared/PageLayout", () => ({
+  PageLayout: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/hooks/useInvoices", () => ({
+  useInvoice: vi.fn(),
+  useInvoices: vi.fn(),
+}));
+
+vi.mock("@/store/wallet", () => ({
+  useWalletStore: vi.fn(),
+}));
+
+const ISSUER = "GACR43ILX6H4PGAOO5QKSZLU4ZJMGT3E66EAUDPLM5J6YTP4Y3PSHWGB";
+const BUYER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+const INVOICE_ID =
+  "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2";
+
+const nowSecs = Math.floor(Date.now() / 1000);
+
+const makeInvoice = (overrides: Partial<Invoice> = {}): Invoice => ({
+  id: INVOICE_ID,
+  status: "Funded",
+  issuer: ISSUER,
+  buyer: BUYER,
+  faceValue: 1_000_000_000n, // 100.00 USDC
+  asset: "USDC",
+  discountBps: 500,
+  fundedAmount: 0n,
+  dueDate: nowSecs + 30 * 24 * 3600,
+  createdAt: nowSecs - 10 * 24 * 3600,
+  fundedAt: nowSecs - 5 * 24 * 3600,
+  shippedAt: null,
+  issuerConfirmed: false,
+  buyerConfirmed: false,
+  repaidAt: null,
+  ...overrides,
+});
+
+describe("InvoiceDetailClient", () => {
+  let mockRefetch: ReturnType<typeof vi.fn>;
+  let mockShipInvoice: ReturnType<typeof vi.fn>;
+  let mockConfirmDelivery: ReturnType<typeof vi.fn>;
+  let mockRepayInvoice: ReturnType<typeof vi.fn>;
+  let mockDefaultInvoice: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // jsdom has no IntersectionObserver; next/link relies on it.
+    class IntersectionObserverMock {
+      readonly root: Element | null = null;
+      readonly rootMargin = "";
+      readonly thresholds: ReadonlyArray<number> = [];
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+      takeRecords = () => [];
+    }
+    (globalThis as any).IntersectionObserver = IntersectionObserverMock;
+
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+
+    mockRefetch = vi.fn().mockResolvedValue(undefined);
+    mockShipInvoice = vi.fn().mockResolvedValue("ship-tx-hash");
+    mockConfirmDelivery = vi.fn().mockResolvedValue("confirm-tx-hash");
+    mockRepayInvoice = vi.fn().mockResolvedValue("repay-tx-hash");
+    mockDefaultInvoice = vi.fn().mockResolvedValue("default-tx-hash");
+
+    vi.mocked(useInvoice).mockReturnValue({
+      invoice: makeInvoice(),
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    } as any);
+
+    vi.mocked(useInvoices).mockReturnValue({
+      shipInvoice: mockShipInvoice,
+      confirmDelivery: mockConfirmDelivery,
+      repayInvoice: mockRepayInvoice,
+      defaultInvoice: mockDefaultInvoice,
+    } as any);
+
+    vi.mocked(useWalletStore).mockReturnValue({
+      address: null,
+      connected: false,
+      network: null,
+      token: null,
+      role: "issuer",
+    } as any);
+  });
+
+  it("renders the loading state while the invoice is being fetched", () => {
+    vi.mocked(useInvoice).mockReturnValue({
+      invoice: undefined,
+      isLoading: true,
+      error: null,
+      refetch: mockRefetch,
+    } as any);
+
+    render(<InvoiceDetailClient invoiceId={INVOICE_ID} />);
+
+    expect(
+      screen.getByText(/Fetching invoice state from ledger\.\.\./i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the not-found state and returns to the dashboard", () => {
+    const push = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({ push } as any);
+    vi.mocked(useInvoice).mockReturnValue({
+      invoice: undefined,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    } as any);
+
+    render(<InvoiceDetailClient invoiceId={INVOICE_ID} />);
+
+    expect(screen.getByText(/Ledger entry not found/i)).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(INVOICE_ID))).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Return to Dashboard/i }),
+    );
+    expect(push).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("renders the full invoice detail view for a funded invoice", () => {
+    render(<InvoiceDetailClient invoiceId={INVOICE_ID} />);
+
+    expect(screen.getByText(/INVOICE AUDIT LEDGER/i)).toBeInTheDocument();
+    expect(screen.getByText(INVOICE_ID)).toBeInTheDocument();
+    expect(screen.getByText(ISSUER)).toBeInTheDocument();
+    expect(screen.getByText(BUYER)).toBeInTheDocument();
+    // Face value obligations + net discount fee both show the amount.
+    expect(screen.getAllByText("100.00 USDC").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Obligation Parties/i)).toBeInTheDocument();
+    expect(screen.getByText(/Escrow Security Vault/i)).toBeInTheDocument();
+    expect(screen.getByText(/Maturity Parameters/i)).toBeInTheDocument();
+    expect(screen.getByText(/Share Invoice/i)).toBeInTheDocument();
+
+    const whatsapp = screen.getByText("WhatsApp").closest("a");
+    expect(whatsapp).toHaveAttribute(
+      "href",
+      expect.stringMatching(/^https:\/\/wa\.me\//),
+    );
+    const telegram = screen.getByText("Telegram").closest("a");
+    expect(telegram).toHaveAttribute(
+      "href",
+      expect.stringMatching(/^https:\/\/t\.me\/share\/url/),
+    );
+  });
+
+  it("hides action buttons when the wallet is not connected", () => {
+    render(<InvoiceDetailClient invoiceId={INVOICE_ID} />);
+
+    expect(screen.queryByText(/Available Action/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /MARK GOODS SHIPPED/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows MARK GOODS SHIPPED for a connected issuer on a funded invoice", () => {
+    vi.mocked(useWalletStore).mockReturnValue({
+      address: ISSUER,
+      connected: true,
+      network: "testnet",
+      token: null,
+      role: "issuer",
+    } as any);
+
+    render(<InvoiceDetailClient invoiceId={INVOICE_ID} />);
+
+    expect(
+      screen.getByRole("button", { name: /MARK GOODS SHIPPED/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /CONFIRM DELIVERY/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows CONFIRM DELIVERY for a connected buyer on an active invoice", () => {
+    vi.mocked(useInvoice).mockReturnValue({
+      invoice: makeInvoice({ status: "Active" }),
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    } as any);
+    vi.mocked(useWalletStore).mockReturnValue({
+      address: BUYER,
+      connected: true,
+      network: "testnet",
+      token: null,
+      role: "buyer",
+    } as any);
+
+    render(<InvoiceDetailClient invoiceId={INVOICE_ID} />);
+
+    expect(
+      screen.getByRole("button", { name: /CONFIRM DELIVERY/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /MARK GOODS SHIPPED/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows REPAY INVOICE for a connected buyer on a confirmed invoice", () => {
+    vi.mocked(useInvoice).mockReturnValue({
+      invoice: makeInvoice({ status: "Confirmed" }),
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    } as any);
+    vi.mocked(useWalletStore).mockReturnValue({
+      address: BUYER,
+      connected: true,
+      network: "testnet",
+      token: null,
+      role: "buyer",
+    } as any);
+
+    render(<InvoiceDetailClient invoiceId={INVOICE_ID} />);
+
+    expect(
+      screen.getByRole("button", { name: /REPAY INVOICE/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows DEFAULT INVOICE for a connected user on an overdue confirmed invoice", () => {
+    vi.mocked(useInvoice).mockReturnValue({
+      invoice: makeInvoice({
+        status: "Confirmed",
+        dueDate: nowSecs - 24 * 3600,
+      }),
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    } as any);
+    vi.mocked(useWalletStore).mockReturnValue({
+      address: ISSUER,
+      connected: true,
+      network: "testnet",
+      token: null,
+      role: "issuer",
+    } as any);
+
+    render(<InvoiceDetailClient invoiceId={INVOICE_ID} />);
+
+    expect(screen.getByText("OVERDUE")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /DEFAULT INVOICE/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show role-gated buttons for the wrong role", () => {
+    vi.mocked(useWalletStore).mockReturnValue({
+      address: BUYER,
+      connected: true,
+      network: "testnet",
+      token: null,
+      role: "buyer",
+    } as any);
+
+    render(<InvoiceDetailClient invoiceId={INVOICE_ID} />);
+
+    // Funded invoice + buyer role: only the issuer may mark goods shipped.
+    expect(
+      screen.queryByRole("button", { name: /MARK GOODS SHIPPED/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Available Action/i)).not.toBeInTheDocument();
+  });
+
+  it("copies the invoice ID to the clipboard", async () => {
+    const writeText = vi
+      .mocked(navigator.clipboard.writeText)
+      .mockResolvedValue(undefined);
+
+    render(<InvoiceDetailClient invoiceId={INVOICE_ID} />);
+
+    fireEvent.click(screen.getByLabelText("Copy invoice ID"));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(INVOICE_ID));
+  });
+
+  it("copies issuer and buyer addresses to the clipboard", async () => {
+    const writeText = vi
+      .mocked(navigator.clipboard.writeText)
+      .mockResolvedValue(undefined);
+
+    render(<InvoiceDetailClient invoiceId={INVOICE_ID} />);
+
+    const copyButtons = screen.getAllByRole("button", { name: /^COPY$/ });
+    expect(copyButtons).toHaveLength(2);
+
+    fireEvent.click(copyButtons[0]);
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(ISSUER));
+
+    fireEvent.click(screen.getByRole("button", { name: /^COPY$/ }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(BUYER));
+
+    expect(await screen.findAllByText("COPIED")).toHaveLength(2);
+  });
+
+  it("copies the invoice link to the clipboard once the URL is available", async () => {
+    const writeText = vi
+      .mocked(navigator.clipboard.writeText)
+      .mockResolvedValue(undefined);
+
+    render(<InvoiceDetailClient invoiceId={INVOICE_ID} />);
+
+    const copyLinkButton = await screen.findByRole("button", {
+      name: /Copy Invoice Link/i,
+    });
+    expect(copyLinkButton).toBeEnabled();
+
+    fireEvent.click(copyLinkButton);
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(window.location.href),
+    );
+    expect(await screen.findByText("LINK COPIED")).toBeInTheDocument();
+  });
+
+  it("calls shipInvoice and shows the pending modal with the returned tx hash", async () => {
+    vi.mocked(useWalletStore).mockReturnValue({
+      address: ISSUER,
+      connected: true,
+      network: "testnet",
+      token: null,
+      role: "issuer",
+    } as any);
+
+    render(<InvoiceDetailClient invoiceId={INVOICE_ID} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /MARK GOODS SHIPPED/i }),
+    );
+
+    expect(
+      screen.getByText(/Marking goods as shipped\.\.\./i),
+    ).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(mockShipInvoice).toHaveBeenCalledWith({ invoiceId: INVOICE_ID }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText("ship-tx-hash")).toBeInTheDocument(),
+    );
+    expect(mockRefetch).toHaveBeenCalled();
+  });
+
+  it("shows the error message and closes the pending modal when an action fails", async () => {
+    mockShipInvoice.mockRejectedValue(new Error("Ship failed"));
+    vi.mocked(useWalletStore).mockReturnValue({
+      address: ISSUER,
+      connected: true,
+      network: "testnet",
+      token: null,
+      role: "issuer",
+    } as any);
+
+    render(<InvoiceDetailClient invoiceId={INVOICE_ID} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /MARK GOODS SHIPPED/i }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent("Ship failed"),
+    );
+    expect(
+      screen.queryByText(/Marking goods as shipped\.\.\./i),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/components/shared/TopStatusBar.test.tsx
+++ b/apps/web/components/shared/TopStatusBar.test.tsx
@@ -61,9 +61,7 @@ describe("TopStatusBar", () => {
     // time is rendered wrapped in parentheses: `(just now)`
     expect(screen.getAllByText("(just now)").length).toBeGreaterThan(0);
     // buyer sliced to first 8 chars
-    expect(
-      screen.getAllByText(/GBUVPV52\.\.\./).length,
-    ).toBeGreaterThan(0);
+    expect(screen.getAllByText(/GBUVPV52\.\.\./).length).toBeGreaterThan(0);
   });
 
   it("formats older event times as hours/days ago", () => {

--- a/apps/web/lib/assets.ts
+++ b/apps/web/lib/assets.ts
@@ -1,5 +1,11 @@
 import type { AssetType } from "@/types";
 
+/**
+ * Number of stroops per whole unit on Stellar (10^7 = 1 unit).
+ *
+ * All on-chain amounts are u128 integers denominated in stroops; divide by
+ * this constant to get a human-readable whole-unit amount.
+ */
 export const STROOP_DIVISOR = 10_000_000;
 
 export interface AssetInfo {
@@ -11,6 +17,12 @@ export interface AssetInfo {
   decimals: number;
 }
 
+/**
+ * Metadata describing each supported asset, keyed by asset type.
+ *
+ * `issuer` falls back to the `NEXT_PUBLIC_USDC_ISSUER` env var (or the
+ * default testnet issuer) for USDC, and is `null` for the native XLM asset.
+ */
 export const ASSET_INFO: Record<AssetType, AssetInfo> = {
   USDC: {
     type: "USDC",
@@ -32,6 +44,22 @@ export const ASSET_INFO: Record<AssetType, AssetInfo> = {
   },
 };
 
+/**
+ * Formats a stroop-denominated amount as a human-readable string with the
+ * asset code appended, e.g. `"1,000.00 USDC"`.
+ *
+ * @param amount - The amount in stroops (10^7 = 1 unit), or `undefined` to
+ *   render a zeroed value for the given asset.
+ * @param asset - The asset code to append. Defaults to `"USDC"`.
+ * @returns The formatted amount string, e.g. `"100.00 USDC"`.
+ *
+ * @example
+ * ```ts
+ * formatAmount(1_000_000_000n); // "100.00 USDC"
+ * formatAmount(10_000_000_000n, "USDC"); // "1,000.00 USDC"
+ * formatAmount(undefined, "XLM"); // "0.00 XLM"
+ * ```
+ */
 export function formatAmount(
   amount: bigint | undefined,
   asset: AssetType = "USDC",
@@ -44,14 +72,44 @@ export function formatAmount(
   return `${formatted} ${asset}`;
 }
 
+/**
+ * Converts a stroop-denominated amount to a plain JavaScript number.
+ *
+ * Note: use sparingly for display only — `Number` loses precision for very
+ * large u128 values.
+ *
+ * @param amount - The amount in stroops (10^7 = 1 unit).
+ * @returns The amount as a whole-unit number (e.g. `1_000_000_000n` → `100`).
+ *
+ * @example
+ * ```ts
+ * stroopsToNumber(1_000_000_000n); // 100
+ * ```
+ */
 export function stroopsToNumber(amount: bigint): number {
   return Number(amount) / STROOP_DIVISOR;
 }
 
+/**
+ * Converts a plain whole-unit number to a stroop-denominated bigint,
+ * rounding down to the nearest stroop.
+ *
+ * @param amount - The amount in whole units (e.g. `100`).
+ * @returns The amount in stroops as a bigint (e.g. `100` → `1_000_000_000n`).
+ *
+ * @example
+ * ```ts
+ * numberToStroops(100); // 1_000_000_000n
+ * numberToStroops(0.5); // 5_000_000n
+ * ```
+ */
 export function numberToStroops(amount: number): bigint {
   return BigInt(Math.floor(amount * STROOP_DIVISOR));
 }
 
+/**
+ * Selectable asset choices for forms and dropdowns (USDC, then XLM).
+ */
 export const ASSET_OPTIONS: { value: AssetType; label: string }[] = [
   { value: "USDC", label: "USDC" },
   { value: "XLM", label: "XLM" },

--- a/apps/web/lib/freighter.ts
+++ b/apps/web/lib/freighter.ts
@@ -4,6 +4,12 @@ import {
   getPublicKey,
 } from "@stellar/freighter-api";
 
+/**
+ * Machine-readable failure codes for Freighter interactions:
+ * - `"user_rejected"` — the user denied the access request.
+ * - `"not_installed"` — the Freighter extension is unavailable.
+ * - `"unknown"` — any other unexpected failure.
+ */
 export type FreighterErrorCode = "user_rejected" | "not_installed" | "unknown";
 
 interface FreighterConnectedResponse {
@@ -15,6 +21,10 @@ interface FreighterAccessResponse {
   error?: string;
 }
 
+/**
+ * Error thrown by the Freighter helpers, carrying a machine-readable
+ * `code` in addition to the standard error `message`.
+ */
 export class FreighterError extends Error {
   readonly code: FreighterErrorCode;
   constructor(code: FreighterErrorCode, message: string) {
@@ -48,6 +58,25 @@ function mapFreighterError(err: unknown): FreighterError {
   return new FreighterError(code, message);
 }
 
+/**
+ * Checks whether the Freighter wallet extension is installed and
+ * connected in the browser.
+ *
+ * Handles both the legacy boolean response and the newer
+ * `{ isConnected }` response shape. Never throws — failures are logged
+ * and reported as `false`.
+ *
+ * @returns `true` when Freighter reports a connection, `false` otherwise
+ *   (including when the extension is absent or the check itself fails).
+ *
+ * @example
+ * ```ts
+ * const installed = await isFreighterInstalled();
+ * if (!installed) {
+ *   // Prompt the user to install Freighter.
+ * }
+ * ```
+ */
 export async function isFreighterInstalled(): Promise<boolean> {
   try {
     const res = await isConnected();
@@ -64,6 +93,28 @@ export async function isFreighterInstalled(): Promise<boolean> {
   }
 }
 
+/**
+ * Connects to the Freighter wallet and requests account access from the
+ * user, showing the Freighter approval popup.
+ *
+ * @returns The connected Stellar public key (address) as a string.
+ *
+ * @throws `FreighterError` with code `"not_installed"` when Freighter is
+ *   missing, `"user_rejected"` when the user denies the request, or
+ *   `"unknown"` for any other failure.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   const address = await connectFreighter();
+ *   useWalletStore.getState().connect(address, "testnet");
+ * } catch (err) {
+ *   if (err instanceof FreighterError && err.code === "user_rejected") {
+ *     // The user cancelled the connection request.
+ *   }
+ * }
+ * ```
+ */
 export async function connectFreighter(): Promise<string> {
   const installed = await isFreighterInstalled();
   if (!installed) {
@@ -94,6 +145,15 @@ export async function connectFreighter(): Promise<string> {
   }
 }
 
+/**
+ * Retrieves the public key of the account currently selected in Freighter
+ * without prompting for a new access approval.
+ *
+ * @returns The Stellar public key of the selected Freighter account.
+ *
+ * @throws `FreighterError` with code `"not_installed"` when Freighter is
+ *   missing, or `"unknown"` when no public key can be returned.
+ */
 export async function getFreighterPublicKey(): Promise<string> {
   const installed = await isFreighterInstalled();
   if (!installed) {


### PR DESCRIPTION
PR Request: Add JSDoc Documentation to freighter.ts
PR Title

docs: add JSDoc documentation to Freighter utilities

Summary

Add comprehensive JSDoc documentation to the exported functions in apps/web/lib/freighter.ts.

The file currently lacks documentation for its exported functions, parameters, and return values. This PR brings the Freighter utility module in line with the existing documentation conventions used throughout the web application, including useProfile.ts, useWallet.ts, useAuth.ts, and useTokenAllowance.ts.

This is a documentation-only change with no intended runtime or behavioral changes.

Closes #538 

Problem

apps/web/lib/freighter.ts contains exported functionality without JSDoc documentation.

Without documentation, contributors need to inspect the implementation or call sites to understand:

What each function accepts.
What each function returns.
The structure and meaning of returned object fields.
How wallet/Freighter-related utilities should be used.
Requirements
Add a JSDoc block above every exported function in:
apps/web/lib/freighter.ts
Include @param documentation for function parameters.
Include @returns documentation for return values.
Document every field when a function returns an object.
Add @example blocks where they provide useful usage guidance.
Follow the existing JSDoc style used in useProfile.ts and useTokenAllowance.ts.
Base all documentation on the actual implementation and types.
Do not alter function behavior or signatures.
Suggested Implementation
Open apps/web/lib/freighter.ts.
Identify every exported function.
Inspect each function's parameters and return type.
Add a descriptive JSDoc block above each exported function.
Document every parameter using @param.
Document the complete return value using @returns.
For returned objects, describe each individual field.
Add realistic @example usage where appropriate.
Compare the result against the existing JSDoc conventions in:
apps/web/hooks/useProfile.ts
apps/web/hooks/useTokenAllowance.ts
Review the final diff to ensure the implementation itself has not changed.
Documentation Structure

Use the repository's existing style, for example:

/**
 * Description of the Freighter utility.
 *
 * @param walletAddress - Description of the wallet address.
 * @returns An object containing:
 * - `fieldA` - Description of field A.
 * - `fieldB` - Description of field B.
 *
 * @example
 * ```ts
 * const result = exampleFunction(walletAddress);
 * ```
 */

The actual names, types, fields, and examples must come from freighter.ts; do not invent API behavior.

Acceptance Criteria
 Every exported function has a JSDoc block.
 Each function's parameters are documented with @param.
 Each function's return value is documented with @returns.
 Every returned-object field is described.
 Useful functions include an @example where appropriate.
 Documentation follows existing project conventions.
 No function signatures are changed.
 No runtime behavior is changed.
 No unrelated refactoring is included.
Validation

Run:

pnpm --filter web exec tsc --noEmit
pnpm build
pnpm --filter web lint
pnpm --filter web test

All checks must pass.

Also verify that CI passes:

Verify TypeScript Frontend & SDK
Verify Go Indexer & API
Out of Scope
Changing Freighter integration behavior.
Changing wallet connection logic.
Changing transaction/signing behavior.
Changing exported function signatures.
Adding new functionality.
Refactoring freighter.ts.
Changes to the shared SDK.
Unrelated documentation updates.
PR Checklist
 Comment .take / claim the issue before starting.
 Add JSDoc to every exported function.
 Document all parameters.
 Document all returned fields.
 Add relevant examples.
 Match existing repository documentation style.
 Confirm implementation has not changed.
 pnpm --filter web exec tsc --noEmit passes.
 pnpm build passes.
 pnpm --filter web lint passes.
 pnpm --filter web test passes.
 CI is green.
 PR contains Closes #.
 No unrelated changes included.