### PR TITLE
test(web): add unit tests for config helpers

### DIFF
--- a/apps/web/lib/config.test.ts
+++ b/apps/web/lib/config.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("config helpers", () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.NEXT_PUBLIC_INVOICE_CONTRACT_ID;
+    delete process.env.NEXT_PUBLIC_POOL_CONTRACT_ID;
+    delete process.env.NEXT_PUBLIC_REGISTRY_CONTRACT_ID;
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    vi.restoreAllMocks();
+  });
+
+  it("validates successfully when all required environment variables are set", async () => {
+    process.env.NEXT_PUBLIC_INVOICE_CONTRACT_ID = "C123";
+    process.env.NEXT_PUBLIC_POOL_CONTRACT_ID = "C456";
+    process.env.NEXT_PUBLIC_REGISTRY_CONTRACT_ID = "C789";
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { validateConfig } = await import("./config");
+
+    const result = validateConfig();
+
+    expect(result).toEqual({
+      missing: [],
+      isConfigured: true,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("identifies missing environment variables and logs a warning", async () => {
+    process.env.NEXT_PUBLIC_INVOICE_CONTRACT_ID = "C123";
+    // NEXT_PUBLIC_POOL_CONTRACT_ID is missing
+    // NEXT_PUBLIC_REGISTRY_CONTRACT_ID is empty string
+    process.env.NEXT_PUBLIC_REGISTRY_CONTRACT_ID = "";
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { validateConfig } = await import("./config");
+
+    const result = validateConfig();
+
+    expect(result.isConfigured).toBe(false);
+    expect(result.missing).toEqual([
+      "NEXT_PUBLIC_POOL_CONTRACT_ID",
+      "NEXT_PUBLIC_REGISTRY_CONTRACT_ID",
+    ]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[TrusTrove] Missing required environment variables: NEXT_PUBLIC_POOL_CONTRACT_ID, NEXT_PUBLIC_REGISTRY_CONTRACT_ID",
+    );
+  });
+
+  it("caches the validation result on subsequent calls", async () => {
+    process.env.NEXT_PUBLIC_INVOICE_CONTRACT_ID = "C123";
+    process.env.NEXT_PUBLIC_POOL_CONTRACT_ID = "C456";
+    process.env.NEXT_PUBLIC_REGISTRY_CONTRACT_ID = "C789";
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { validateConfig } = await import("./config");
+
+    const firstResult = validateConfig();
+
+    // Mutate env vars after initial validation to prove cached result is returned
+    delete process.env.NEXT_PUBLIC_INVOICE_CONTRACT_ID;
+
+    const secondResult = validateConfig();
+
+    expect(secondResult).toBe(firstResult);
+    expect(secondResult.isConfigured).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,8 +3,5 @@ packages:
   - "packages/*"
 
 allowBuilds:
-  esbuild: set this to true or false
+  esbuild: false
   unrs-resolver: true
-
-onlyBuiltDependencies:
-  - unrs-resolver


### PR DESCRIPTION
## 📌 Overview
Closes #515

This PR introduces a dedicated unit test suite (`apps/web/lib/config.test.ts`) for the web application's configuration helper (`apps/web/lib/config.ts`) to ensure robust environment validation and prevent silent regressions.

---

## 🧪 Changes Included
- **Unit Test File (`apps/web/lib/config.test.ts`)**:
  - `validates successfully when all required environment variables are set`: Verifies `validateConfig()` returns `isConfigured: true` and no warnings are logged.
  - `identifies missing environment variables and logs a warning`: Verifies `validateConfig()` flags unconfigured or empty string environment variables, populates `missing[]`, and logs an explicit console warning.
  - `caches the validation result on subsequent calls`: Confirms memoization behavior by ensuring subsequent calls return the cached result instance even if `process.env` is modified post-initialization.
- **Workspace Build Config (`pnpm-workspace.yaml`)**:
  - Configured `allowBuilds` for `esbuild: false` to resolve pnpm workspace build warnings.

---

## ✅ How to Test & Verification
Run the unit test target specifically for `config.test.ts`:

```bash
pnpm --filter web test config.test.ts
