### PR TITLE
docs(web): add JSDoc to undocumented hooks

### DIFF
--- a/apps/web/hooks/useBalances.ts
+++ b/apps/web/hooks/useBalances.ts
@@ -11,6 +11,23 @@ export interface Balances {
 const HORIZON_URL =
   process.env.NEXT_PUBLIC_HORIZON_URL || "https://horizon-testnet.stellar.org";
 
+/**
+ * Custom hook for fetching the connected wallet's USDC and XLM balances
+ * from the Stellar Horizon API.
+ *
+ * Polls automatically every 30 seconds when a wallet is connected.
+ * Returns zeroed balances when the account does not yet exist on-chain.
+ *
+ * @returns An object containing:
+ *   - `balances` — Object with `usdc` and `xlm` string balances (or `null` if unavailable).
+ *   - `loading` — `true` while balances are being fetched.
+ *   - `error` — Error message string if the fetch failed, otherwise `null`.
+ *   - `refetch` — Function to manually trigger a balance refresh.
+ *
+ * @example
+ * const { balances, loading, error, refetch } = useBalances();
+ * console.log(balances.usdc); // "100.50" or null
+ */
 export function useBalances() {
   const { address, connected } = useWalletStore();
   const [balances, setBalances] = useState<Balances>({ usdc: null, xlm: null });

--- a/apps/web/hooks/useEvents.ts
+++ b/apps/web/hooks/useEvents.ts
@@ -6,6 +6,28 @@ interface UseRecentEventsOptions {
   refetchInterval?: number;
 }
 
+/**
+ * Custom hook for fetching recent platform events from the indexer API.
+ *
+ * Wraps React Query to provide automatic caching and optional polling.
+ *
+ * @param limit - Maximum number of events to return. Defaults to the API's
+ *   own limit when omitted.
+ * @param options - Optional configuration.
+ * @param options.refetchInterval - Polling interval in milliseconds. When set,
+ *   the query refetches on this cadence.
+ *
+ * @returns An object containing:
+ *   - `events` — Array of event objects (defaults to `[]` while loading).
+ *   - `isLoading` — `true` while the events query is in flight.
+ *   - `error` — Fetch error, or `null` if none.
+ *   - `refetch` — Function to manually re-trigger the events query.
+ *
+ * @example
+ * const { events, isLoading, error } = useRecentEvents(20, {
+ *   refetchInterval: 60_000,
+ * });
+ */
 export function useRecentEvents(
   limit?: number,
   options?: UseRecentEventsOptions,

--- a/apps/web/hooks/useFocusTrap.ts
+++ b/apps/web/hooks/useFocusTrap.ts
@@ -2,6 +2,30 @@
 
 import { useEffect, useRef } from "react";
 
+/**
+ * Client-side hook that traps keyboard focus inside a container element,
+ * commonly used for modals, drawers, and dialogs.
+ *
+ * When `enabled` is `true`, Tab and Shift+Tab cycle through focusable
+ * elements within the referenced container. Pressing Escape calls the
+ * optional `onEscape` callback. Previous focus is restored on disable.
+ *
+ * @param enabled - Whether the focus trap is active. Pass `false` to disable.
+ * @param onEscape - Optional callback invoked when the Escape key is pressed
+ *   while the trap is active.
+ *
+ * @returns A `RefObject<T>` that must be attached to the trap container element.
+ *
+ * @example
+ * const dialogRef = useFocusTrap<HTMLDivElement>(isOpen, onClose);
+ *
+ * return (
+ *   <div ref={dialogRef} role="dialog">
+ *     <button>First</button>
+ *     <button>Last</button>
+ *   </div>
+ * );
+ */
 export function useFocusTrap<T extends HTMLElement>(
   enabled: boolean,
   onEscape?: () => void,

--- a/apps/web/hooks/useTxHistory.ts
+++ b/apps/web/hooks/useTxHistory.ts
@@ -111,6 +111,31 @@ async function fetchPage(address: string, cursor?: string) {
   return { items, nextCursor };
 }
 
+/**
+ * Custom hook for paginated transaction history from the Stellar Horizon API.
+ *
+ * Fetches transactions for the given address, filtering to only those that
+ * invoke TrusTrove smart contracts (registry, invoice, pool, escrow).
+ * Supports cursor-based forward/backward pagination with 10 items per page.
+ *
+ * @param address - The Stellar public key to fetch transaction history for.
+ *   The query is disabled (skipped) when the address is an empty string.
+ *
+ * @returns An object containing:
+ *   - `transactions` — Array of `TxHistoryItem` for the current page (defaults to `[]`).
+ *   - `isLoading` — `true` while transactions are being fetched.
+ *   - `error` — Fetch error, or `null` if none.
+ *   - `hasNext` — `true` if there are more pages forward.
+ *   - `hasPrev` — `true` if there are pages before the current one.
+ *   - `goNext` — Advances to the next page of results.
+ *   - `goPrev` — Returns to the previous page of results.
+ *   - `page` — Current 1-based page number.
+ *   - `refetch` — Function to manually re-trigger the query.
+ *
+ * @example
+ * const { transactions, isLoading, hasNext, goNext, goPrev } =
+ *   useTxHistory(walletAddress);
+ */
 export function useTxHistory(address: string): TxHistoryResult {
   const [cursorStack, setCursorStack] = useState<(string | undefined)[]>([
     undefined,


### PR DESCRIPTION
Add JSDoc documentation to useBalances, useRecentEvents, useFocusTrap, and useTxHistory, matching the style established by useProfile, useWallet, useAuth, and useTokenAllowance. Each block documents params, return shape, and includes a usage example.

Closed: #529