### PR TITLE
test(web): add unit test file for useStats hook

### DIFF
--- a/apps/web/components/ui/button.test.tsx
+++ b/apps/web/components/ui/button.test.tsx
@@ -15,7 +15,7 @@ describe("Button", () => {
     render(
       <Button variant="destructive" size="sm">
         Delete
-      </Button>
+      </Button>,
     );
     const button = screen.getByRole("button", { name: "Delete" });
     expect(button).toBeInTheDocument();
@@ -39,8 +39,11 @@ describe("Button", () => {
     render(
       <Button asChild>
         <a href="/test">Link</a>
-      </Button>
+      </Button>,
     );
-    expect(screen.getByRole("link", { name: "Link" })).toHaveAttribute("href", "/test");
+    expect(screen.getByRole("link", { name: "Link" })).toHaveAttribute(
+      "href",
+      "/test",
+    );
   });
 });

--- a/apps/web/hooks/useStats.test.ts
+++ b/apps/web/hooks/useStats.test.ts
@@ -1,0 +1,113 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useStats } from "./useStats";
+import { useQuery } from "@tanstack/react-query";
+import { getProtocolStats, ProtocolStats } from "@/lib/api";
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getProtocolStats: vi.fn(),
+}));
+
+const mockStats: ProtocolStats = {
+  total_usdc_financed: "1000000",
+  active_invoice_count: 5,
+  total_invoices: 42,
+  total_repaid: 30,
+  total_defaulted: 2,
+  average_yield_bps: 850,
+  pool_utilization_bps: 6500,
+  registered_issuers: 12,
+};
+
+describe("useStats", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns stats on default/successful render", () => {
+    vi.mocked(useQuery).mockReturnValue({
+      data: mockStats,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as any);
+
+    const { result } = renderHook(() => useStats());
+
+    expect(result.current.stats).toEqual(mockStats);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("shows loading state while stats are being fetched", () => {
+    vi.mocked(useQuery).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    } as any);
+
+    const { result } = renderHook(() => useStats());
+
+    expect(result.current.stats).toBeUndefined();
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("surfaces an error state when the fetch fails", () => {
+    const fetchError = new Error("Stats fetch failed");
+    vi.mocked(useQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: fetchError,
+      refetch: vi.fn(),
+    } as any);
+
+    const { result } = renderHook(() => useStats());
+
+    expect(result.current.error).toEqual(fetchError);
+    expect(result.current.stats).toBeUndefined();
+  });
+
+  it("exposes a refetch function that re-triggers the query", () => {
+    const mockRefetch = vi.fn();
+    vi.mocked(useQuery).mockReturnValue({
+      data: mockStats,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    } as any);
+
+    const { result } = renderHook(() => useStats());
+    result.current.refetch();
+
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("configures the query with the expected key, fetcher, and caching options", () => {
+    vi.mocked(useQuery).mockReturnValue({
+      data: mockStats,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as any);
+
+    renderHook(() => useStats());
+
+    expect(useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ["protocolStats"],
+        refetchInterval: 60000,
+        staleTime: 30000,
+        retry: 3,
+      }),
+    );
+
+    const call = vi.mocked(useQuery).mock.calls[0][0] as any;
+    call.queryFn();
+    expect(getProtocolStats).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.6",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 2.0.0
       '@stellar/stellar-sdk':
         specifier: ^13.3.0
-        version: 13.3.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 13.3.0(supports-color@7.2.0)
       '@tanstack/react-query':
         specifier: ^5.101.0
         version: 5.101.2(react@18.3.1)
@@ -93,6 +93,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.6
+        version: 14.6.6(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^20
         version: 20.19.43
@@ -140,7 +143,7 @@ importers:
         version: 2.0.0
       '@stellar/stellar-sdk':
         specifier: ^13.0.0
-        version: 13.3.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+        version: 13.3.0(supports-color@7.2.0)
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -998,6 +1001,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.6':
+    resolution: {integrity: sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -4092,10 +4101,10 @@ snapshots:
     transitivePeerDependencies:
       - bare-url
 
-  '@stellar/stellar-sdk@13.3.0(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@stellar/stellar-sdk@13.3.0(supports-color@7.2.0)':
     dependencies:
       '@stellar/stellar-base': 13.1.0
-      axios: 1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
+      axios: 1.18.1(supports-color@7.2.0)
       bignumber.js: 9.3.1
       eventsource: 2.0.2
       feaxios: 0.0.23
@@ -4158,6 +4167,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.31
       '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@testing-library/user-event@14.6.6(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -4224,7 +4237,7 @@ snapshots:
       '@typescript-eslint/parser': 8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.62.1
       '@typescript-eslint/type-utils': 8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@8.57.1(supports-color@7.2.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.62.1
       eslint: 8.57.1(supports-color@7.2.0)
       ignore: 7.0.5
@@ -4268,7 +4281,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.62.1
       '@typescript-eslint/typescript-estree': 8.62.1(supports-color@7.2.0)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.62.1(eslint@8.57.1(supports-color@7.2.0))(typescript@5.9.3)
       debug: 4.4.3(supports-color@7.2.0)
       eslint: 8.57.1(supports-color@7.2.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -4293,7 +4306,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.62.1(eslint@8.57.1(supports-color@7.2.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1(supports-color@7.2.0))
       '@typescript-eslint/scope-manager': 8.62.1
@@ -4590,9 +4603,9 @@ snapshots:
 
   axe-core@4.12.1: {}
 
-  axios@1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
+  axios@1.18.1(supports-color@7.2.0):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
+      follow-redirects: 1.16.0
       form-data: 4.0.6
       https-proxy-agent: 5.0.1(supports-color@7.2.0)
       proxy-from-env: 2.1.0
@@ -5030,8 +5043,8 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.62.1(@typescript-eslint/parser@8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       '@typescript-eslint/parser': 8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       eslint: 8.57.1(supports-color@7.2.0)
-      eslint-import-resolver-node: 0.3.10(supports-color@7.2.0)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0))(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1(supports-color@7.2.0))
       eslint-plugin-react: 7.37.5(eslint@8.57.1(supports-color@7.2.0))
@@ -5043,7 +5056,7 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-import-resolver-node@0.3.10(supports-color@7.2.0):
+  eslint-import-resolver-node@0.3.10:
     dependencies:
       debug: 3.2.7(supports-color@7.2.0)
       is-core-module: 2.16.2
@@ -5051,7 +5064,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0))(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@7.2.0)
@@ -5066,14 +5079,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10(supports-color@7.2.0))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0))(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0))(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
       debug: 3.2.7(supports-color@7.2.0)
     optionalDependencies:
       '@typescript-eslint/parser': 8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3)
       eslint: 8.57.1(supports-color@7.2.0)
-      eslint-import-resolver-node: 0.3.10(supports-color@7.2.0)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0))(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5087,8 +5100,8 @@ snapshots:
       debug: 3.2.7(supports-color@7.2.0)
       doctrine: 2.1.0
       eslint: 8.57.1(supports-color@7.2.0)
-      eslint-import-resolver-node: 0.3.10(supports-color@7.2.0)
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10(supports-color@7.2.0))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)
+      eslint-import-resolver-node: 0.3.10
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)(typescript@5.9.3))(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0))(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0))(eslint@8.57.1(supports-color@7.2.0))(supports-color@7.2.0)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -5278,9 +5291,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0(debug@4.4.3(supports-color@7.2.0)):
-    optionalDependencies:
-      debug: 4.4.3(supports-color@7.2.0)
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:


### PR DESCRIPTION
Closes #513

## Summary

`useStats` (`apps/web/hooks/useStats.ts`) had no colocated test file, so any regression to its loading/error/data behavior would land silently. This PR adds `useStats.test.ts` covering the hook's primary states and behaviors, following the existing pattern used by `usePool.test.ts`. It also fixes two pre-existing CI failures that were uncovered while getting this PR green (see below).

## Files

**New files:**
- `apps/web/hooks/useStats.test.ts` — test file for `useStats`

**Modified files:**
- `apps/web/package.json` / `pnpm-lock.yaml` — added missing `@testing-library/user-event` devDependency (see "Unrelated CI fixes")
- `apps/web/components/ui/button.test.tsx` — prettier formatting fix only, no logic change (see "Unrelated CI fixes")

`useStats.ts` itself was not changed; only test coverage was added.

## Implementation details

- Mocks `@tanstack/react-query`'s `useQuery` and `@/lib/api`'s `getProtocolStats`, matching the mocking approach already used in `usePool.test.ts` for other query-backed hooks in this codebase.
- Uses `@testing-library/react`'s `renderHook` to exercise the hook directly, and asserts on the shape returned by `useStats()` (`stats`, `isLoading`, `error`, `refetch`).
- A `mockStats: ProtocolStats` fixture matches the real `ProtocolStats` interface fields (`total_usdc_financed`, `active_invoice_count`, `total_invoices`, `total_repaid`, `total_defaulted`, `average_yield_bps`, `pool_utilization_bps`, `registered_issuers`) so the test stays type-safe against the actual API contract.

## Tests added

1. **Default/successful render** — `useQuery` returns populated data; asserts `stats` equals the mock data, `isLoading` is `false`, `error` is `null`.
2. **Loading state** — `useQuery` returns `isLoading: true` with no data; asserts `stats` is `undefined` and `isLoading` is `true`.
3. **Error state** — `useQuery` returns an `Error`; asserts `error` is surfaced and `stats` stays `undefined`.
4. **Refetch interaction** — asserts that calling `result.current.refetch()` invokes the underlying query's `refetch` function exactly once.
5. **Query configuration** — asserts `useQuery` is called with the expected `queryKey` (`["protocolStats"]`), `refetchInterval` (60000), `staleTime` (30000), and `retry` (3), and that invoking the captured `queryFn` calls `getProtocolStats`.

This covers default, loading, and error render states plus the interaction/callback path (`refetch`), satisfying the "at least 3 test cases covering default / edge / interaction paths" acceptance criterion.

## Unrelated CI fixes

While verifying, the `Verify TypeScript Frontend & SDK` required check was red on `main`-equivalent state for reasons unrelated to `useStats`:

1. `components/ui/button.test.tsx` (added in a prior PR, #619) imports `@testing-library/user-event`, which was never added as a dependency. This made the whole vitest run fail to resolve that import, failing the CI job before it ever reached the Prettier check step. Fixed by adding `@testing-library/user-event` to `apps/web/package.json` devDependencies.
2. Once the import failure was fixed, CI proceeded to the `Check Formatting` step (previously never reached) and caught a pre-existing Prettier violation in the same `button.test.tsx` file. Fixed by running `prettier --write` on that file only — no logic changes.

Both were verified to reproduce identically without any of my changes, confirming they predate this PR and were simply masked by the earlier-failing step. Fixing them was necessary to get the required CI job green per this issue's Definition of Done.

## How to test

```bash
pnpm --filter web exec tsc --noEmit
pnpm --filter web lint
pnpm --filter web test
npx prettier --check apps/web
```

All 310 tests across 41 test files pass (including the 5 new `useStats` tests). `tsc --noEmit` and `lint` are clean (only pre-existing, unrelated warnings remain). Both required CI jobs (`Verify TypeScript Frontend & SDK`, `Verify Go Indexer & API`) are green on this PR. The `Vercel` check failure is a pre-existing project-authorization issue unrelated to this change and is not one of the two required jobs.
