### PR TITLE
test(web): add ErrorBoundary unit tests

### DIFF
--- a/apps/web/components/shared/ErrorBoundary.test.tsx
+++ b/apps/web/components/shared/ErrorBoundary.test.tsx
@@ -34,7 +34,12 @@ describe("ErrorBoundary", () => {
       );
     }
 
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const windowConsoleError = vi
+      .spyOn(window.console, "error")
+      .mockImplementation(() => {});
     try {
       render(
         <ErrorBoundary>
@@ -57,6 +62,7 @@ describe("ErrorBoundary", () => {
       expect(screen.getByText("Child content")).toBeInTheDocument();
     } finally {
       consoleError.mockRestore();
+      windowConsoleError.mockRestore();
     }
   });
 
@@ -67,7 +73,12 @@ describe("ErrorBoundary", () => {
         <button onClick={reset}>Reset boundary</button>
       </div>
     ));
-    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const windowConsoleError = vi
+      .spyOn(window.console, "error")
+      .mockImplementation(() => {});
 
     try {
       render(
@@ -91,6 +102,7 @@ describe("ErrorBoundary", () => {
       expect(fallback).toHaveBeenCalled();
     } finally {
       consoleError.mockRestore();
+      windowConsoleError.mockRestore();
     }
   });
 });

--- a/apps/web/components/shared/ErrorBoundary.test.tsx
+++ b/apps/web/components/shared/ErrorBoundary.test.tsx
@@ -35,24 +35,29 @@ describe("ErrorBoundary", () => {
     }
 
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-    render(
-      <ErrorBoundary>
-        <ResettableChild />
-      </ErrorBoundary>,
-    );
+    try {
+      render(
+        <ErrorBoundary>
+          <ResettableChild />
+        </ErrorBoundary>,
+      );
 
-    fireEvent.click(screen.getByRole("button", { name: "Cause error" }));
+      fireEvent.click(screen.getByRole("button", { name: "Cause error" }));
 
-    expect(
-      screen.getByText("Something went wrong loading this."),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Child failed")).toBeInTheDocument();
+      expect(
+        screen.getByText("Something went wrong loading this."),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Child failed")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+      fireEvent.click(screen.getByRole("button", { name: "Try again" }));
 
-    expect(screen.getByRole("button", { name: "Cause error" })).toBeInTheDocument();
-    expect(screen.getByText("Child content")).toBeInTheDocument();
-    consoleError.mockRestore();
+      expect(
+        screen.getByRole("button", { name: "Cause error" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Child content")).toBeInTheDocument();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it("uses the custom fallback with the error and reset callback", () => {
@@ -64,21 +69,28 @@ describe("ErrorBoundary", () => {
     ));
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    render(
-      <ErrorBoundary fallback={fallback} context="test">
-        <ThrowingChild shouldThrow={true} />
-      </ErrorBoundary>,
-    );
+    try {
+      render(
+        <ErrorBoundary fallback={fallback} context="test">
+          <ThrowingChild shouldThrow={true} />
+        </ErrorBoundary>,
+      );
 
-    expect(screen.getByText("Custom fallback: Child failed")).toBeInTheDocument();
-    expect(fallback).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "Child failed" }),
-      expect.any(Function),
-    );
+      expect(
+        screen.getByText("Custom fallback: Child failed"),
+      ).toBeInTheDocument();
+      expect(fallback).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Child failed" }),
+        expect.any(Function),
+      );
 
-    fireEvent.click(screen.getByRole("button", { name: "Reset boundary" }));
-    expect(screen.getByText("Custom fallback: Child failed")).toBeInTheDocument();
-    expect(fallback).toHaveBeenCalled();
-    consoleError.mockRestore();
+      fireEvent.click(screen.getByRole("button", { name: "Reset boundary" }));
+      expect(
+        screen.getByText("Custom fallback: Child failed"),
+      ).toBeInTheDocument();
+      expect(fallback).toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });

--- a/apps/web/components/shared/ErrorBoundary.test.tsx
+++ b/apps/web/components/shared/ErrorBoundary.test.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+function ThrowingChild({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error("Child failed");
+  }
+
+  return <p>Child content</p>;
+}
+
+describe("ErrorBoundary", () => {
+  it("renders its children by default", () => {
+    render(
+      <ErrorBoundary>
+        <p>Child content</p>
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Child content")).toBeInTheDocument();
+  });
+
+  it("renders the default fallback and resets after clicking Try again", () => {
+    function ResettableChild() {
+      const [shouldThrow, setShouldThrow] = useState(false);
+
+      return (
+        <>
+          <button onClick={() => setShouldThrow(true)}>Cause error</button>
+          <ThrowingChild shouldThrow={shouldThrow} />
+        </>
+      );
+    }
+
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <ErrorBoundary>
+        <ResettableChild />
+      </ErrorBoundary>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cause error" }));
+
+    expect(
+      screen.getByText("Something went wrong loading this."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Child failed")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(screen.getByRole("button", { name: "Cause error" })).toBeInTheDocument();
+    expect(screen.getByText("Child content")).toBeInTheDocument();
+    consoleError.mockRestore();
+  });
+
+  it("uses the custom fallback with the error and reset callback", () => {
+    const fallback = vi.fn((error: Error, reset: () => void) => (
+      <div>
+        <p>Custom fallback: {error.message}</p>
+        <button onClick={reset}>Reset boundary</button>
+      </div>
+    ));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary fallback={fallback} context="test">
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Custom fallback: Child failed")).toBeInTheDocument();
+    expect(fallback).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Child failed" }),
+      expect.any(Function),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset boundary" }));
+    expect(screen.getByText("Custom fallback: Child failed")).toBeInTheDocument();
+    expect(fallback).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});


### PR DESCRIPTION
Closes #505

## Summary
- add a colocated unit test file for `ErrorBoundary`
- cover normal child rendering
- cover child errors and the default fallback UI
- cover the Try again recovery interaction
- cover custom fallback rendering, error propagation, context, and reset callback behavior

## Verification
- `pnpm --filter web test -- components/shared/ErrorBoundary.test.tsx` — passed (13 files, 55 tests)
- `pnpm build` — passed
- `pnpm --filter web lint` — passed with two pre-existing unused-import warnings
- `pnpm --filter web exec tsc --noEmit` — reports pre-existing errors in `InvoiceStatus.test.tsx` and `WalletConnect.test.tsx`

## Notes
React logs the intentionally thrown child error during the ErrorBoundary tests; those console traces are expected and the tests pass.