### PR TITLE
test(web): add unit tests for utils helpers

### DIFF
--- a/apps/web/lib/utils.test.ts
+++ b/apps/web/lib/utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { cn } from "./utils";
+
+describe("cn", () => {
+  it("concatenates multiple class names into a single string", () => {
+    expect(cn("foo", "bar")).toBe("foo bar");
+  });
+
+  it("returns an empty string when no arguments are provided", () => {
+    expect(cn()).toBe("");
+  });
+
+  it("strips falsy values and only keeps truthy class names", () => {
+    expect(cn(false, null, undefined, 0, "", "active", "hidden")).toBe(
+      "active hidden",
+    );
+  });
+
+  it("resolves conflicting Tailwind utility classes in favour of the last value", () => {
+    expect(cn("p-2", "p-4")).toBe("p-4");
+    expect(cn("text-sm", "text-lg", "text-xl")).toBe("text-xl");
+    expect(cn("bg-red-500", "bg-blue-500")).toBe("bg-blue-500");
+  });
+
+  it("accepts clsx-style conditional objects and arrays", () => {
+    expect(cn("base", { active: true, disabled: false })).toBe("base active");
+    expect(cn(["text-sm", "font-bold"], "text-lg")).toBe("font-bold text-lg");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a colocated unit test file for the web utility helpers in `apps/web/lib/utils.ts`.

## Changes

* Added `apps/web/lib/utils.test.ts`
* Covered normal/default utility behavior
* Covered edge/boundary behavior
* Covered applicable interaction/callback behavior
* Followed the existing web test conventions

## Testing

Verified with:

* `pnpm --filter web test`
* `pnpm --filter web exec tsc --noEmit`
* `pnpm --filter web lint`
* `pnpm build`

Closes #517
