### PR TITLE
feat(indexer): add AttestationSubmitted event handler and expose risk…

### DIFF
--- a/indexer/db/migrations/008_add_invoice_attestation.sql
+++ b/indexer/db/migrations/008_add_invoice_attestation.sql
@@ -1,0 +1,6 @@
+-- Add attestation columns to invoices table.
+-- These are nullable because most invoices will not have an attestation yet.
+ALTER TABLE invoices ADD COLUMN attestation_agent_id VARCHAR;
+ALTER TABLE invoices ADD COLUMN risk_score_bps INTEGER;
+ALTER TABLE invoices ADD COLUMN evidence_hash VARCHAR(64);
+ALTER TABLE invoices ADD COLUMN attested_at BIGINT;

--- a/indexer/db/queries.go
+++ b/indexer/db/queries.go
@@ -12,21 +12,25 @@ import (
 )
 
 type DbInvoice struct {
-	ID               string `json:"id"`
-	Issuer           string `json:"issuer"`
-	Buyer            string `json:"buyer"`
-	FaceValue        string `json:"face_value"` // BigInt represented as string for JSON/SQL numeric safety
-	DiscountBps      int    `json:"discount_bps"`
-	FundedAmount     string `json:"funded_amount"`
-	DueDate          int64  `json:"due_date"`
-	Status           string `json:"status"`
-	CreatedAt        int64  `json:"created_at"`
-	FundedAt         *int64 `json:"funded_at"`
-	ShippedAt        *int64 `json:"shipped_at"`
-	IssuerConfirmed  bool   `json:"issuer_confirmed"`
-	BuyerConfirmed   bool   `json:"buyer_confirmed"`
-	BuyerConfirmedAt *int64 `json:"buyer_confirmed_at"`
-	RepaidAt         *int64 `json:"repaid_at"`
+	ID                 string  `json:"id"`
+	Issuer             string  `json:"issuer"`
+	Buyer              string  `json:"buyer"`
+	FaceValue          string  `json:"face_value"` // BigInt represented as string for JSON/SQL numeric safety
+	DiscountBps        int     `json:"discount_bps"`
+	FundedAmount       string  `json:"funded_amount"`
+	DueDate            int64   `json:"due_date"`
+	Status             string  `json:"status"`
+	CreatedAt          int64   `json:"created_at"`
+	FundedAt           *int64  `json:"funded_at"`
+	ShippedAt          *int64  `json:"shipped_at"`
+	IssuerConfirmed    bool    `json:"issuer_confirmed"`
+	BuyerConfirmed     bool    `json:"buyer_confirmed"`
+	BuyerConfirmedAt   *int64  `json:"buyer_confirmed_at"`
+	RepaidAt           *int64  `json:"repaid_at"`
+	AttestationAgentID *string `json:"attestation_agent_id"`
+	RiskScoreBps       *int    `json:"risk_score_bps"`
+	EvidenceHash       *string `json:"evidence_hash"`
+	AttestedAt         *int64  `json:"attested_at"`
 }
 
 type DbPoolStats struct {
@@ -85,28 +89,34 @@ func InsertInvoice(ctx context.Context, inv *DbInvoice) error {
 	query := `
 		INSERT INTO invoices (
 			id, issuer, buyer, face_value, discount_bps, funded_amount, due_date, status, created_at,
-			funded_at, shipped_at, issuer_confirmed, buyer_confirmed, buyer_confirmed_at, repaid_at
+			funded_at, shipped_at, issuer_confirmed, buyer_confirmed, buyer_confirmed_at, repaid_at,
+			attestation_agent_id, risk_score_bps, evidence_hash, attested_at
 		) VALUES (
 			@id, @issuer, @buyer, @face_value, @discount_bps, @funded_amount, @due_date, @status, @created_at,
-			@funded_at, @shipped_at, @issuer_confirmed, @buyer_confirmed, @buyer_confirmed_at, @repaid_at
+			@funded_at, @shipped_at, @issuer_confirmed, @buyer_confirmed, @buyer_confirmed_at, @repaid_at,
+			@attestation_agent_id, @risk_score_bps, @evidence_hash, @attested_at
 		)
 	`
 	args := pgx.NamedArgs{
-		"id":                 inv.ID,
-		"issuer":             inv.Issuer,
-		"buyer":              inv.Buyer,
-		"face_value":         inv.FaceValue,
-		"discount_bps":       inv.DiscountBps,
-		"funded_amount":      inv.FundedAmount,
-		"due_date":           inv.DueDate,
-		"status":             inv.Status,
-		"created_at":         inv.CreatedAt,
-		"funded_at":          inv.FundedAt,
-		"shipped_at":         inv.ShippedAt,
-		"issuer_confirmed":   inv.IssuerConfirmed,
-		"buyer_confirmed":    inv.BuyerConfirmed,
-		"buyer_confirmed_at": inv.BuyerConfirmedAt,
-		"repaid_at":          inv.RepaidAt,
+		"id":                   inv.ID,
+		"issuer":               inv.Issuer,
+		"buyer":                inv.Buyer,
+		"face_value":           inv.FaceValue,
+		"discount_bps":         inv.DiscountBps,
+		"funded_amount":        inv.FundedAmount,
+		"due_date":             inv.DueDate,
+		"status":               inv.Status,
+		"created_at":           inv.CreatedAt,
+		"funded_at":            inv.FundedAt,
+		"shipped_at":           inv.ShippedAt,
+		"issuer_confirmed":     inv.IssuerConfirmed,
+		"buyer_confirmed":      inv.BuyerConfirmed,
+		"buyer_confirmed_at":   inv.BuyerConfirmedAt,
+		"repaid_at":            inv.RepaidAt,
+		"attestation_agent_id": inv.AttestationAgentID,
+		"risk_score_bps":       inv.RiskScoreBps,
+		"evidence_hash":        inv.EvidenceHash,
+		"attested_at":          inv.AttestedAt,
 	}
 	_, err := Pool.Exec(ctx, query, args)
 	if err != nil {
@@ -118,7 +128,8 @@ func InsertInvoice(ctx context.Context, inv *DbInvoice) error {
 func GetInvoiceByID(ctx context.Context, id string) (*DbInvoice, error) {
 	query := `
 		SELECT id, issuer, buyer, face_value, discount_bps, funded_amount, due_date, status, created_at,
-			funded_at, shipped_at, issuer_confirmed, buyer_confirmed, buyer_confirmed_at, repaid_at
+			funded_at, shipped_at, issuer_confirmed, buyer_confirmed, buyer_confirmed_at, repaid_at,
+			attestation_agent_id, risk_score_bps, evidence_hash, attested_at
 		FROM invoices WHERE id = $1
 	`
 	var inv DbInvoice
@@ -126,6 +137,7 @@ func GetInvoiceByID(ctx context.Context, id string) (*DbInvoice, error) {
 		&inv.ID, &inv.Issuer, &inv.Buyer, &inv.FaceValue, &inv.DiscountBps, &inv.FundedAmount,
 		&inv.DueDate, &inv.Status, &inv.CreatedAt, &inv.FundedAt, &inv.ShippedAt,
 		&inv.IssuerConfirmed, &inv.BuyerConfirmed, &inv.BuyerConfirmedAt, &inv.RepaidAt,
+		&inv.AttestationAgentID, &inv.RiskScoreBps, &inv.EvidenceHash, &inv.AttestedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -165,7 +177,8 @@ func GetInvoicesPage(ctx context.Context, status, issuer string, limit, offset i
 	query := fmt.Sprintf(`
 		SELECT 
 			id, issuer, buyer, face_value, discount_bps, funded_amount, due_date, status, created_at,
-			funded_at, shipped_at, issuer_confirmed, buyer_confirmed, buyer_confirmed_at, repaid_at
+			funded_at, shipped_at, issuer_confirmed, buyer_confirmed, buyer_confirmed_at, repaid_at,
+			attestation_agent_id, risk_score_bps, evidence_hash, attested_at
 		FROM invoices%s
 		ORDER BY created_at DESC
 		LIMIT $%d OFFSET $%d
@@ -185,6 +198,7 @@ func GetInvoicesPage(ctx context.Context, status, issuer string, limit, offset i
 			&inv.ID, &inv.Issuer, &inv.Buyer, &inv.FaceValue, &inv.DiscountBps, &inv.FundedAmount,
 			&inv.DueDate, &inv.Status, &inv.CreatedAt, &inv.FundedAt, &inv.ShippedAt,
 			&inv.IssuerConfirmed, &inv.BuyerConfirmed, &inv.BuyerConfirmedAt, &inv.RepaidAt,
+			&inv.AttestationAgentID, &inv.RiskScoreBps, &inv.EvidenceHash, &inv.AttestedAt,
 		); err != nil {
 			return nil, 0, fmt.Errorf("queries: scan invoice: %w", err)
 		}
@@ -267,6 +281,19 @@ func UpdateInvoiceStatus(ctx context.Context, id string, status string) error {
 	_, err := Pool.Exec(ctx, query, status, id)
 	if err != nil {
 		return fmt.Errorf("queries: update invoice status: %w", err)
+	}
+	return nil
+}
+
+func UpdateInvoiceAttestation(ctx context.Context, invoiceID, agentID, evidenceHash string, riskScoreBps int, attestedAt int64) error {
+	query := `
+		UPDATE invoices 
+		SET attestation_agent_id = $1, risk_score_bps = $2, evidence_hash = $3, attested_at = $4
+		WHERE id = $5
+	`
+	_, err := Pool.Exec(ctx, query, agentID, riskScoreBps, evidenceHash, attestedAt, invoiceID)
+	if err != nil {
+		return fmt.Errorf("queries: update invoice attestation: %w", err)
 	}
 	return nil
 }

--- a/indexer/db/queries_test.go
+++ b/indexer/db/queries_test.go
@@ -228,3 +228,71 @@ func TestLocateMigrationDir(t *testing.T) {
 		}
 	}
 }
+
+func TestUpdateInvoiceAttestation(t *testing.T) {
+	skipIfNoDB(t)
+
+	ctx := context.Background()
+	id := fmt.Sprintf("attest-test%d", time.Now().UnixNano())
+	inv := &DbInvoice{
+		ID:           id,
+		Issuer:       "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+		Buyer:        "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+		FaceValue:    "1000000000",
+		DiscountBps:  0,
+		FundedAmount: "0",
+		DueDate:      time.Now().Add(30 * 24 * time.Hour).Unix(),
+		Status:       "Created",
+		CreatedAt:    time.Now().Unix(),
+	}
+
+	if err := InsertInvoice(ctx, inv); err != nil {
+		t.Fatalf("InsertInvoice: %v", err)
+	}
+	t.Cleanup(func() {
+		if Pool != nil {
+			Pool.Exec(ctx, "DELETE FROM invoices WHERE id = $1", id)
+		}
+	})
+
+	// Attestation fields should start as nil
+	got, err := GetInvoiceByID(ctx, id)
+	if err != nil || got == nil {
+		t.Fatalf("GetInvoiceByID: err=%v, got=%v", err, got)
+	}
+	if got.AttestationAgentID != nil {
+		t.Errorf("AttestationAgentID: expected nil, got %v", *got.AttestationAgentID)
+	}
+	if got.RiskScoreBps != nil {
+		t.Errorf("RiskScoreBps: expected nil, got %v", *got.RiskScoreBps)
+	}
+
+	// Update attestation
+	agentID := "agent_underwrite"
+	evidenceHash := "abc123"
+	riskScoreBps := 3500
+	attestedAt := time.Now().Unix()
+
+	err = UpdateInvoiceAttestation(ctx, id, agentID, evidenceHash, riskScoreBps, attestedAt)
+	if err != nil {
+		t.Fatalf("UpdateInvoiceAttestation: %v", err)
+	}
+
+	// Verify attestation fields are populated
+	got, err = GetInvoiceByID(ctx, id)
+	if err != nil || got == nil {
+		t.Fatalf("GetInvoiceByID after attestation: err=%v, got=%v", err, got)
+	}
+	if got.AttestationAgentID == nil || *got.AttestationAgentID != agentID {
+		t.Errorf("AttestationAgentID: got %v, want %q", got.AttestationAgentID, agentID)
+	}
+	if got.RiskScoreBps == nil || *got.RiskScoreBps != riskScoreBps {
+		t.Errorf("RiskScoreBps: got %v, want %d", got.RiskScoreBps, riskScoreBps)
+	}
+	if got.EvidenceHash == nil || *got.EvidenceHash != evidenceHash {
+		t.Errorf("EvidenceHash: got %v, want %q", got.EvidenceHash, evidenceHash)
+	}
+	if got.AttestedAt == nil || *got.AttestedAt != attestedAt {
+		t.Errorf("AttestedAt: got %v, want %d", got.AttestedAt, attestedAt)
+	}
+}

--- a/indexer/listener/handlers.go
+++ b/indexer/listener/handlers.go
@@ -285,6 +285,47 @@ func (l *EventListener) handleInvoiceDefaulted(ctx context.Context, event Soroba
 	return nil
 }
 
+func (l *EventListener) handleAttestationSubmitted(ctx context.Context, event SorobanEvent, ledgerClosedAt int64) error {
+	// Topic format: ["AttestationSubmitted" / "submit_attestation", invoice_id_bytes, agent_id_symbol]
+	// Value: risk_score (u32)
+	if len(event.Topic) < 2 {
+		return fmt.Errorf("invalid topic length for attestation event")
+	}
+
+	var idVal xdr.ScVal
+	err := xdr.SafeUnmarshalBase64(event.Topic[1], &idVal)
+	if err != nil {
+		return fmt.Errorf("parse topic invoice_id: %w", err)
+	}
+	invoiceID := xdrutil.ParseBytes(idVal)
+
+	// Parse agent_id from topic[2] if present
+	agentID := ""
+	if len(event.Topic) >= 3 {
+		var agentVal xdr.ScVal
+		err = xdr.SafeUnmarshalBase64(event.Topic[2], &agentVal)
+		if err == nil && agentVal.Sym != nil {
+			agentID = string(*agentVal.Sym)
+		}
+	}
+
+	// Parse risk_score from value
+	riskScoreBps := 0
+	var val xdr.ScVal
+	err = xdr.SafeUnmarshalBase64(event.Value, &val)
+	if err == nil {
+		riskScoreBps = int(xdrutil.ParseU32(val))
+	}
+
+	err = db.UpdateInvoiceAttestation(ctx, invoiceID, agentID, "", riskScoreBps, ledgerClosedAt)
+	if err != nil {
+		return err
+	}
+
+	slog.Info("Indexed event: AttestationSubmitted", "id", invoiceID, "agentID", agentID, "riskScoreBps", riskScoreBps)
+	return nil
+}
+
 func (l *EventListener) handleEvent(ctx context.Context, event SorobanEvent) error {
 	if len(event.Topic) == 0 {
 		return fmt.Errorf("event topic is empty")
@@ -331,6 +372,8 @@ func (l *EventListener) handleEvent(ctx context.Context, event SorobanEvent) err
 		err = l.handleInvoiceRepaid(ctx, event, serverKP, ledgerClosedAt)
 	case "trigger_default", "InvoiceDefaulted":
 		err = l.handleInvoiceDefaulted(ctx, event, serverKP)
+	case "submit_attestation", "AttestationSubmitted":
+		err = l.handleAttestationSubmitted(ctx, event, ledgerClosedAt)
 	default:
 		slog.Debug("Skipping unhandled contract event", "name", eventName)
 		return nil

--- a/indexer/listener/handlers_test.go
+++ b/indexer/listener/handlers_test.go
@@ -348,3 +348,91 @@ func TestHandleDeliveryConfirmed(t *testing.T) {
 		t.Errorf("Status after confirmed: got %q, want %q", got.Status, "Confirmed")
 	}
 }
+
+func TestHandleAttestationSubmitted(t *testing.T) {
+	skipIfNoDB(t)
+
+	l := newTestListener()
+	ctx := context.Background()
+
+	const (
+		issuer = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+		buyer  = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"
+	)
+	rawIDBytes := []byte(fmt.Sprintf("attested%d", time.Now().UnixNano()))
+	invoiceIDHex := fmt.Sprintf("%x", rawIDBytes)
+
+	inv := &db.DbInvoice{
+		ID:           invoiceIDHex,
+		Issuer:       issuer,
+		Buyer:        buyer,
+		FaceValue:    "1000000000",
+		FundedAmount: "0",
+		DueDate:      time.Now().Add(30 * 24 * time.Hour).Unix(),
+		Status:       "Created",
+		CreatedAt:    time.Now().Unix(),
+	}
+	if err := db.InsertInvoice(ctx, inv); err != nil {
+		t.Fatalf("setup InsertInvoice: %v", err)
+	}
+	t.Cleanup(func() {
+		if db.Pool != nil {
+			db.Pool.Exec(ctx, "DELETE FROM invoices WHERE id = $1", invoiceIDHex)
+		}
+	})
+
+	idScBytes := xdr.ScBytes(rawIDBytes)
+	idTopic := encodeScVal(xdr.ScVal{Type: xdr.ScValTypeScvBytes, Bytes: &idScBytes})
+
+	// agent_id as a symbol topic
+	agentSymbol := xdr.ScSymbol("agent_underwrite")
+	agentTopic := encodeScVal(xdr.ScVal{Type: xdr.ScValTypeScvSymbol, Sym: &agentSymbol})
+
+	// risk_score = 2500 bps as u32 value
+	riskScore := xdr.Uint32(2500)
+	riskVal := xdr.ScVal{Type: xdr.ScValTypeScvU32, U32: &riskScore}
+
+	event := SorobanEvent{
+		ID:             fmt.Sprintf("event-attestation-%d", time.Now().UnixNano()),
+		ContractID:     "CAKEWH7SJCXGV2MH2WZYIX3QDPTSSBQFXYVYBOWAGLNBBZMPLE2US6CS",
+		Ledger:         1010,
+		LedgerClosedAt: time.Now().Format(time.RFC3339),
+		Topic:          []string{encodeSymbol("AttestationSubmitted"), idTopic, agentTopic},
+		Value:          encodeScVal(riskVal),
+	}
+
+	if err := l.handleAttestationSubmitted(ctx, event, time.Now().Unix()); err != nil {
+		t.Fatalf("handleAttestationSubmitted: %v", err)
+	}
+
+	got, err := db.GetInvoiceByID(ctx, invoiceIDHex)
+	if err != nil || got == nil {
+		t.Fatalf("GetInvoiceByID after attestation: err=%v, got=%v", err, got)
+	}
+	if got.AttestationAgentID == nil || *got.AttestationAgentID != "agent_underwrite" {
+		t.Errorf("AttestationAgentID: got %v, want %q", got.AttestationAgentID, "agent_underwrite")
+	}
+	if got.RiskScoreBps == nil || *got.RiskScoreBps != 2500 {
+		t.Errorf("RiskScoreBps: got %v, want %d", got.RiskScoreBps, 2500)
+	}
+}
+
+func TestHandleAttestationSubmitted_ShortTopic(t *testing.T) {
+	l := newTestListener()
+	ctx := context.Background()
+
+	// Event with only one topic element should fail
+	event := SorobanEvent{
+		ID:             "event-short-topic",
+		ContractID:     "CAKEWH7SJCXGV2MH2WZYIX3QDPTSSBQFXYVYBOWAGLNBBZMPLE2US6CS",
+		Ledger:         1011,
+		LedgerClosedAt: time.Now().Format(time.RFC3339),
+		Topic:          []string{encodeSymbol("AttestationSubmitted")},
+		Value:          encodeScVal(xdr.ScVal{Type: xdr.ScValTypeScvVoid}),
+	}
+
+	err := l.handleAttestationSubmitted(ctx, event, time.Now().Unix())
+	if err == nil {
+		t.Fatal("expected error for short topic, got nil")
+	}
+}


### PR DESCRIPTION
… score on invoices

Add handler for the AttestationSubmitted contract event emitted by submit_attestation, which was previously silently dropped by the indexer. This surfaces the off-chain verification result for invoices.

Changes:
- New migration 008_add_invoice_attestation.sql adds nullable attestation columns (attestation_agent_id, risk_score_bps, evidence_hash, attested_at) to the invoices table
- New UpdateInvoiceAttestation query function in db/queries.go
- Extended DbInvoice struct with attestation fields (nullable)
- Added handleAttestationSubmitted handler and wired into the handleEvent switch for both "submit_attestation" and "AttestationSubmitted" topic forms
- Updated all SQL queries (GetInvoiceByID, GetInvoicesPage, InsertInvoice) to include the new columns
- Added TestHandleAttestationSubmitted and TestHandleAttestationSubmitted_ShortTopic in handlers_test.go
- Added TestUpdateInvoiceAttestation in queries_test.go

Closes #498

🤖 Generated with Codebuff