### PR TITLE
Add Unit Tests for useAppError Hook

### DIFF
--- a/apps/web/hooks/useAppError.test.ts
+++ b/apps/web/hooks/useAppError.test.ts
@@ -1,0 +1,76 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { useAppError } from "./useAppError";
+
+describe("useAppError", () => {
+  it("initial state has no error", () => {
+    const { result } = renderHook(() => useAppError());
+    expect(result.current.error).toBeNull();
+  });
+
+  it("handleError sets a user-friendly message from an Error instance", () => {
+    const { result } = renderHook(() => useAppError());
+
+    act(() => {
+      result.current.handleError(new Error("Wallet not connected"));
+    });
+
+    expect(result.current.error).toBe(
+      "Please connect your wallet to perform this action",
+    );
+  });
+
+  it("handleError preserves the message from an unknown Error instance", () => {
+    const { result } = renderHook(() => useAppError());
+
+    act(() => {
+      result.current.handleError(new Error("Disk full"));
+    });
+
+    expect(result.current.error).toBe("Disk full");
+  });
+
+  it("handleError with an object having a message property extracts the message", () => {
+    const { result } = renderHook(() => useAppError());
+
+    act(() => {
+      result.current.handleError({ message: "Rate limit exceeded" });
+    });
+
+    expect(result.current.error).toBe("Rate limit exceeded");
+  });
+
+  it("clearError resets the error to null", () => {
+    const { result } = renderHook(() => useAppError());
+
+    act(() => {
+      result.current.handleError(new Error("fail"));
+    });
+    expect(result.current.error).toBe("fail");
+
+    act(() => {
+      result.current.clearError();
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("setError allows setting an arbitrary error string directly", () => {
+    const { result } = renderHook(() => useAppError());
+
+    act(() => {
+      result.current.setError("Custom error");
+    });
+
+    expect(result.current.error).toBe("Custom error");
+  });
+
+  it("handleError with a string error returns the string as-is", () => {
+    const { result } = renderHook(() => useAppError());
+
+    act(() => {
+      result.current.handleError("raw string error");
+    });
+
+    expect(result.current.error).toBe("raw string error");
+  });
+});


### PR DESCRIPTION
##closed #512 

Add a colocated test file for useAppError to ensure its core behaviour is covered and protected against regressions.

The tests should verify the hook’s default behaviour, propdriven state changes, edge cases, and interaction/callback handlers. The test suite should contain at least three meaningful test cases and pass successfully with the existing web test command.

Scope:
  Create apps/web/hooks/useAppError.test.ts.
  Test the default rendered state.
  Test state changes driven by props.
  Test relevant interactions and callback handlers.
  Verify edge/error paths where applicable.
  Ensure all existing TypeScript, lint, build, and test checks remain green.