### PR TITLE
test(web): cover Navbar role guard

### DIFF
--- a/apps/web/components/shared/Navbar.test.tsx
+++ b/apps/web/components/shared/Navbar.test.tsx
@@ -12,7 +12,10 @@ vi.mock("./SkeletonLoader", () => ({ SkeletonShimmer: () => <span /> }));
 vi.mock("@/hooks/useBalances", () => ({ useBalances: () => ({ balances: { usdc: "1", xlm: "2" }, loading: false }) }));
 vi.mock("@/hooks/useProfile", () => ({ useProfile: () => ({ isVerified: false }) }));
 vi.mock("@/store/wallet", () => ({ useWalletStore: () => ({ role: "issuer", setRole, connected: true }) }));
-vi.mock("lucide-react", () => new Proxy({}, { get: () => () => <span /> }));
+vi.mock("lucide-react", () => {
+  const Icon = () => null;
+  return { Wallet: Icon, Shield: Icon, Terminal: Icon, ExternalLink: Icon, Menu: Icon, X: Icon };
+});
 
 describe("Navbar role select", () => {
   beforeEach(() => setRole.mockClear());

--- a/apps/web/components/shared/Navbar.test.tsx
+++ b/apps/web/components/shared/Navbar.test.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Navbar } from "./Navbar";
+
+const setRole = vi.fn();
+
+vi.mock("next/link", () => ({ default: ({ children, ...props }: React.PropsWithChildren<{ href: string }>) => <a {...props}>{children}</a> }));
+vi.mock("next/navigation", () => ({ usePathname: () => "/dashboard" }));
+vi.mock("./WalletConnect", () => ({ WalletConnect: () => <button>Connect</button> }));
+vi.mock("./SkeletonLoader", () => ({ SkeletonShimmer: () => <span /> }));
+vi.mock("@/hooks/useBalances", () => ({ useBalances: () => ({ balances: { usdc: "1", xlm: "2" }, loading: false }) }));
+vi.mock("@/hooks/useProfile", () => ({ useProfile: () => ({ isVerified: false }) }));
+vi.mock("@/store/wallet", () => ({ useWalletStore: () => ({ role: "issuer", setRole, connected: true }) }));
+vi.mock("lucide-react", () => new Proxy({}, { get: () => () => <span /> }));
+
+describe("Navbar role select", () => {
+  beforeEach(() => setRole.mockClear());
+
+  it("accepts valid roles", () => {
+    render(<Navbar />);
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "buyer" } });
+    expect(setRole).toHaveBeenCalledWith("buyer");
+  });
+
+  it("ignores values outside the role union", () => {
+    render(<Navbar />);
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "admin" } });
+    expect(setRole).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #681.

Adds focused Navbar regression coverage for the role-select guard introduced by #543. The tests verify valid roles reach `setRole` and out-of-union values are ignored.

## Validation

- `pnpm install --no-frozen-lockfile --child-concurrency=1 --network-concurrency=1` — blocked by Windows `EPERM` while pnpm copied `tslib@2.8.1` from the local store
- `pnpm --filter web exec vitest run apps/web/components/shared/Navbar.test.tsx` — could not start because `vitest` was unavailable after the failed install
- Full `pnpm typecheck`, lint, build, and test commands were not run for the same dependency-install limitation

The change is test-only and follows the existing web test conventions. CI should provide the clean dependency environment needed to execute the regression test.
