### PR TITLE
feat(web): add verification badge on invoice cards

### DIFF
--- a/apps/web/components/invoice/InvoiceCard.tsx
+++ b/apps/web/components/invoice/InvoiceCard.tsx
@@ -3,6 +3,8 @@
 import React, { useState } from "react";
 import { Invoice } from "@/types";
 import { InvoiceStatus } from "./InvoiceStatus";
+import { VerificationBadge } from "./VerificationBadge";
+import type { VerificationState } from "./VerificationBadge";
 import { useInvoices } from "@/hooks/useInvoices";
 import { Button } from "@/components/ui/button";
 import { useWalletStore } from "@/store/wallet";
@@ -110,6 +112,12 @@ export const InvoiceCard = React.memo(function InvoiceCard({
 
   const showActions = !!address;
 
+  // Derive per-invoice verification state from attestation fields
+  const verificationState: VerificationState =
+    invoice.riskScoreBps != null ? "verified" : "unverified";
+  // "failed" is reserved for a future explicit failure signal from the indexer;
+  // it is intentionally not wired to fake data here.
+
   // Render actions depending on state
   return (
     <div
@@ -145,7 +153,13 @@ export const InvoiceCard = React.memo(function InvoiceCard({
             Invoice obligation
           </h3>
         </div>
-        <InvoiceStatus status={invoice.status} />
+        <div className="flex items-center gap-2">
+          <VerificationBadge
+            state={verificationState}
+            riskScoreBps={invoice.riskScoreBps}
+          />
+          <InvoiceStatus status={invoice.status} />
+        </div>
       </div>
 
       <div className="grid grid-cols-2 gap-4 mb-4">

--- a/apps/web/components/invoice/VerificationBadge.test.tsx
+++ b/apps/web/components/invoice/VerificationBadge.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { VerificationBadge } from "./VerificationBadge";
+
+describe("VerificationBadge", () => {
+  it("renders 'Unverified' when state is unverified", () => {
+    render(<VerificationBadge state="unverified" />);
+    const badge = screen.getByRole("status");
+    expect(badge).toHaveTextContent("Unverified");
+    expect(badge).toHaveAttribute("aria-label", "Verification: Unverified");
+  });
+
+  it("renders 'Verified · risk score N%' when state is verified with a risk score", () => {
+    render(<VerificationBadge state="verified" riskScoreBps={2500} />);
+    const badge = screen.getByRole("status");
+    expect(badge).toHaveTextContent("Verified · risk score 25.0%");
+    expect(badge).toHaveAttribute(
+      "aria-label",
+      "Verification: verified, risk score 25.0 percent",
+    );
+  });
+
+  it("renders 'Verified' when state is verified without a risk score", () => {
+    render(<VerificationBadge state="verified" riskScoreBps={null} />);
+    const badge = screen.getByRole("status");
+    expect(badge).toHaveTextContent("Verified");
+    expect(badge).toHaveAttribute("aria-label", "Verification: Verified");
+  });
+
+  it("renders 'Verification failed' when state is failed", () => {
+    render(<VerificationBadge state="failed" />);
+    const badge = screen.getByRole("status");
+    expect(badge).toHaveTextContent("Verification failed");
+    expect(badge).toHaveAttribute(
+      "aria-label",
+      "Verification: Verification failed",
+    );
+  });
+
+  it("formats risk score as percentage with one decimal", () => {
+    render(<VerificationBadge state="verified" riskScoreBps={3333} />);
+    const badge = screen.getByRole("status");
+    expect(badge).toHaveTextContent("Verified · risk score 33.3%");
+  });
+});

--- a/apps/web/components/invoice/VerificationBadge.tsx
+++ b/apps/web/components/invoice/VerificationBadge.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import React from "react";
+import { ShieldCheck, ShieldAlert, ShieldQuestion } from "lucide-react";
+
+export type VerificationState = "unverified" | "verified" | "failed";
+
+interface VerificationBadgeProps {
+  /** The attestation verification state for this invoice. */
+  state: VerificationState;
+  /** Risk score in basis points (0-10000). Only used when state is "verified". */
+  riskScoreBps?: number | null;
+}
+
+const stateConfig: Record<
+  VerificationState,
+  { bg: string; border: string; text: string; label: string }
+> = {
+  unverified: {
+    bg: "bg-slate-500/5",
+    border: "border-slate-500/20",
+    text: "text-slate-400",
+    label: "Unverified",
+  },
+  verified: {
+    bg: "bg-emerald-500/5",
+    border: "border-emerald-500/25",
+    text: "text-emerald-400",
+    label: "Verified",
+  },
+  failed: {
+    bg: "bg-rose-500/5",
+    border: "border-rose-500/25",
+    text: "text-rose-400",
+    label: "Verification failed",
+  },
+};
+
+export function VerificationBadge({
+  state,
+  riskScoreBps,
+}: VerificationBadgeProps) {
+  const config = stateConfig[state];
+
+  const displayText =
+    state === "verified" && riskScoreBps != null
+      ? `Verified · risk score ${(riskScoreBps / 100).toFixed(1)}%`
+      : config.label;
+
+  const ariaLabel =
+    state === "verified" && riskScoreBps != null
+      ? `Verification: verified, risk score ${(riskScoreBps / 100).toFixed(1)} percent`
+      : `Verification: ${config.label}`;
+
+  const Icon =
+    state === "verified"
+      ? ShieldCheck
+      : state === "failed"
+        ? ShieldAlert
+        : ShieldQuestion;
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[10px] font-bold font-mono tracking-wider uppercase border ${config.bg} ${config.border} ${config.text}`}
+      role="status"
+      aria-label={ariaLabel}
+      title={displayText}
+    >
+      <Icon className="w-3.5 h-3.5" aria-hidden="true" />
+      <span>{displayText}</span>
+    </span>
+  );
+}

--- a/apps/web/components/shared/Navbar.test.tsx
+++ b/apps/web/components/shared/Navbar.test.tsx
@@ -5,16 +5,36 @@ import { Navbar } from "./Navbar";
 
 const setRole = vi.fn();
 
-vi.mock("next/link", () => ({ default: ({ children, ...props }: React.PropsWithChildren<{ href: string }>) => <a {...props}>{children}</a> }));
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    ...props
+  }: React.PropsWithChildren<{ href: string }>) => <a {...props}>{children}</a>,
+}));
 vi.mock("next/navigation", () => ({ usePathname: () => "/dashboard" }));
-vi.mock("./WalletConnect", () => ({ WalletConnect: () => <button>Connect</button> }));
+vi.mock("./WalletConnect", () => ({
+  WalletConnect: () => <button>Connect</button>,
+}));
 vi.mock("./SkeletonLoader", () => ({ SkeletonShimmer: () => <span /> }));
-vi.mock("@/hooks/useBalances", () => ({ useBalances: () => ({ balances: { usdc: "1", xlm: "2" }, loading: false }) }));
-vi.mock("@/hooks/useProfile", () => ({ useProfile: () => ({ isVerified: false }) }));
-vi.mock("@/store/wallet", () => ({ useWalletStore: () => ({ role: "issuer", setRole, connected: true }) }));
+vi.mock("@/hooks/useBalances", () => ({
+  useBalances: () => ({ balances: { usdc: "1", xlm: "2" }, loading: false }),
+}));
+vi.mock("@/hooks/useProfile", () => ({
+  useProfile: () => ({ isVerified: false }),
+}));
+vi.mock("@/store/wallet", () => ({
+  useWalletStore: () => ({ role: "issuer", setRole, connected: true }),
+}));
 vi.mock("lucide-react", () => {
   const Icon = () => null;
-  return { Wallet: Icon, Shield: Icon, Terminal: Icon, ExternalLink: Icon, Menu: Icon, X: Icon };
+  return {
+    Wallet: Icon,
+    Shield: Icon,
+    Terminal: Icon,
+    ExternalLink: Icon,
+    Menu: Icon,
+    X: Icon,
+  };
 });
 
 describe("Navbar role select", () => {
@@ -22,13 +42,17 @@ describe("Navbar role select", () => {
 
   it("accepts valid roles", () => {
     render(<Navbar />);
-    fireEvent.change(screen.getByRole("combobox"), { target: { value: "buyer" } });
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "buyer" },
+    });
     expect(setRole).toHaveBeenCalledWith("buyer");
   });
 
   it("ignores values outside the role union", () => {
     render(<Navbar />);
-    fireEvent.change(screen.getByRole("combobox"), { target: { value: "admin" } });
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "admin" },
+    });
     expect(setRole).not.toHaveBeenCalled();
   });
 });

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -33,6 +33,11 @@ export interface Invoice {
   buyerConfirmed: boolean;
   buyerConfirmedAt?: number | null;
   repaidAt: number | null;
+  /** Nullable attestation fields from the indexer (set once Underwrite verifies the invoice). */
+  attestationAgentId?: string | null;
+  riskScoreBps?: number | null;
+  evidenceHash?: string | null;
+  attestedAt?: number | null;
 }
 
 export interface PoolStats {

--- a/packages/sdk/src/types/schemas.ts
+++ b/packages/sdk/src/types/schemas.ts
@@ -111,6 +111,10 @@ export const invoiceSchema = z.object({
   buyerConfirmed: booleanSchema,
   buyerConfirmedAt: nullableNumberSchema.optional(),
   repaidAt: nullableNumberSchema,
+  attestationAgentId: z.string().nullable().optional(),
+  riskScoreBps: z.number().nullable().optional(),
+  evidenceHash: z.string().nullable().optional(),
+  attestedAt: nullableNumberSchema.optional(),
 });
 
 export function parseInvoice(native: unknown): Invoice {


### PR DESCRIPTION
Add a VerificationBadge component that displays per-invoice attestation status (Unverified / Verified · risk score N% / Verification failed) next to the existing InvoiceStatus badge. Extend the SDK Invoice type with nullable attestation fields (attestationAgentId, riskScoreBps, evidenceHash, attestedAt) and update the Zod parser to accept them.

Closes #500
