### PR TITLE
fix(web): add re-entrancy guard to connectWallet

### DIFF
--- a/apps/web/hooks/useWallet.ts
+++ b/apps/web/hooks/useWallet.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { getNetworkDetails } from "@stellar/freighter-api";
 import { useWalletStore } from "@/store/wallet";
 import { connectFreighter, FreighterError } from "@/lib/freighter";
@@ -80,7 +80,11 @@ export function useWallet() {
    * address and defaults the network to `'testnet'`. The connection is rejected
    * if Freighter reports a different active network.
    */
+  const connectingRef = useRef(false);
+
   const connectWallet = async () => {
+    if (connectingRef.current) return;
+    connectingRef.current = true;
     setLoading(true);
     setError(null);
     setErrorCode(null);
@@ -105,6 +109,7 @@ export function useWallet() {
       disconnect();
     } finally {
       setLoading(false);
+      connectingRef.current = false;
     }
   };
 


### PR DESCRIPTION
## Summary

Adds a `connectingRef` re-entrancy guard to `connectWallet` in `useWallet.ts` to prevent overlapping wallet connection attempts from racing and leaving wallet state inconsistent.

## Changes

- Added a `useRef(false)` flag (`connectingRef`) that gates entry to `connectWallet`.
- If a connection is already in progress (`connectingRef.current === true`), subsequent calls return immediately.
- The ref is reset in the `finally` block to ensure cleanup even on errors.

## Problem

`connectWallet` had no guard against concurrent calls. If two overlapping calls raced (e.g. a network-switch flow firing while a separate connect was already in flight), whichever `connectFreighter()`/`validateFreighterNetwork()` resolved last silently overwrites the other's `loading`/`error`/store state, with no defined winner.

Closes #640

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>