### PR TITLE
fix(web): always run network validation in validateFreighterNetwork

### DIFF
--- a/apps/web/hooks/useWallet.ts
+++ b/apps/web/hooks/useWallet.ts
@@ -17,16 +17,7 @@ interface FreighterNetworkDetails {
   network?: string;
 }
 
-function hasFreighterExtension(): boolean {
-  return typeof window !== "undefined" && "freighter" in window;
-}
-
 async function validateFreighterNetwork(): Promise<void> {
-  // The connection helper already handles wallet availability. This guard also
-  // keeps mocked connections and non-browser environments from attempting to
-  // access the extension API when no Freighter provider is present.
-  if (!hasFreighterExtension()) return;
-
   const details = (await getNetworkDetails()) as FreighterNetworkDetails;
   const network = details.network?.trim().toLowerCase();
 


### PR DESCRIPTION
## Summary

Removes the fragile `hasFreighterExtension()` / `"freighter" in window` guard that silently skipped network validation when the Freighter extension wasn't detected as a synchronous global.

## Changes

- Removed `hasFreighterExtension()` function entirely.
- `validateFreighterNetwork()` now calls `getNetworkDetails()` unconditionally.
- Any failure to reach the extension (e.g. not installed, wrong environment) is caught by the upstream `try/catch` in `connectWallet` and surfaced as an error to the user — rather than silently passing.

## Problem

Some Freighter versions communicate via `@stellar/freighter-api`'s internal messaging rather than exposing a synchronous `window.freighter` global. This meant the check could report `false` even when Freighter was installed and had just succeeded at `connectFreighter()`, causing network validation to be skipped entirely — exactly the safety hole this function exists to prevent.

Closes #641

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>