### PR TITLE
fix(web): reset useTxHistory pagination when address changes

### DIFF
--- a/apps/web/hooks/useTxHistory.ts
+++ b/apps/web/hooks/useTxHistory.ts
@@ -2,7 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { Horizon } from "@stellar/stellar-sdk";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import type { TxHistoryItem } from "@/types";
 
 const HORIZON_URL =
@@ -170,6 +170,11 @@ export function useTxHistory(address: string): TxHistoryResult {
   ]);
   const [page, setPage] = useState(0);
   const cursor = cursorStack[page];
+
+  useEffect(() => {
+    setCursorStack([undefined]);
+    setPage(0);
+  }, [address]);
 
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: ["txHistory", address, cursor],


### PR DESCRIPTION
## Summary

Adds a `useEffect` keyed on `address` that resets `cursorStack` to `[undefined]` and `page` to `0` whenever the connected wallet address changes.

## Problem

`cursorStack` and `page` were local `useState` that persisted across renders regardless of the `address` argument. If the connected wallet address changed (disconnect/reconnect with a different account, or a role switch), the user could remain on e.g. `page: 3` with a Horizon `cursor` value scoped to the old account. Reusing an old account's cursor against a new account's transaction stream is undefined behavior — most likely an empty or broken page instead of resetting to the newest transactions.

## Solution

A `useEffect` now watches `address` and resets both pagination states to their initial values whenever it changes, ensuring the user always sees page 1 of the new address's transaction history.

Closes #642

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>