### PR TITLE
fix(web): add confirmation dialog to invoice detail action buttons

### DIFF
--- a/apps/web/app/invoice/[invoiceId]/InvoiceDetailClient.test.tsx
+++ b/apps/web/app/invoice/[invoiceId]/InvoiceDetailClient.test.tsx
@@ -30,6 +30,17 @@ vi.mock("@/store/wallet", () => ({
   useWalletStore: vi.fn(),
 }));
 
+// The confirmation dialog is rendered by the app shell, which is not present
+// in these isolated component tests. Mock the confirm store so that requesting
+// an action immediately invokes it (the same behavior as clicking CONFIRM).
+vi.mock("@/store/confirmDialog", () => ({
+  useConfirmDialogStore: vi.fn(() => ({
+    request: vi.fn((action: { fn: () => void }) => action.fn()),
+    cancel: vi.fn(),
+    pendingAction: null,
+  })),
+}));
+
 const ISSUER = "GACR43ILX6H4PGAOO5QKSZLU4ZJMGT3E66EAUDPLM5J6YTP4Y3PSHWGB";
 const BUYER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 const INVOICE_ID =

--- a/apps/web/app/invoice/[invoiceId]/InvoiceDetailClient.tsx
+++ b/apps/web/app/invoice/[invoiceId]/InvoiceDetailClient.tsx
@@ -24,6 +24,7 @@ import {
   Share2,
 } from "lucide-react";
 import { formatAmount } from "@/lib/assets";
+import { useConfirmDialogStore } from "@/store/confirmDialog";
 
 interface InvoiceDetailClientProps {
   invoiceId: string;
@@ -56,6 +57,7 @@ export default function InvoiceDetailClient({
   const { invoice, isLoading, refetch } = useInvoice(invoiceId);
   const { shipInvoice, confirmDelivery, repayInvoice, defaultInvoice } =
     useInvoices();
+  const { request: requestConfirmation } = useConfirmDialogStore();
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -439,11 +441,16 @@ export default function InvoiceDetailClient({
                     className="w-full"
                     disabled={submitting}
                     onClick={() =>
-                      handleAction(
-                        () => shipInvoice({ invoiceId: invoice.id }),
-                        "Marking goods as shipped...",
-                        "Unable to mark goods as shipped.",
-                      )
+                      requestConfirmation({
+                        label: "Mark Goods Shipped",
+                        invoiceId: invoice.id,
+                        fn: () =>
+                          handleAction(
+                            () => shipInvoice({ invoiceId: invoice.id }),
+                            "Marking goods as shipped...",
+                            "Unable to mark goods as shipped.",
+                          ),
+                      })
                     }
                   >
                     MARK GOODS SHIPPED
@@ -454,11 +461,16 @@ export default function InvoiceDetailClient({
                     className="w-full"
                     disabled={submitting}
                     onClick={() =>
-                      handleAction(
-                        () => confirmDelivery({ invoiceId: invoice.id }),
-                        "Confirming delivery...",
-                        "Unable to confirm delivery.",
-                      )
+                      requestConfirmation({
+                        label: "Confirm Delivery",
+                        invoiceId: invoice.id,
+                        fn: () =>
+                          handleAction(
+                            () => confirmDelivery({ invoiceId: invoice.id }),
+                            "Confirming delivery...",
+                            "Unable to confirm delivery.",
+                          ),
+                      })
                     }
                   >
                     CONFIRM DELIVERY
@@ -469,11 +481,16 @@ export default function InvoiceDetailClient({
                     className="w-full"
                     disabled={submitting}
                     onClick={() =>
-                      handleAction(
-                        () => repayInvoice({ invoiceId: invoice.id }),
-                        "Repaying invoice...",
-                        "Unable to repay invoice.",
-                      )
+                      requestConfirmation({
+                        label: "Repay Invoice",
+                        invoiceId: invoice.id,
+                        fn: () =>
+                          handleAction(
+                            () => repayInvoice({ invoiceId: invoice.id }),
+                            "Repaying invoice...",
+                            "Unable to repay invoice.",
+                          ),
+                      })
                     }
                   >
                     REPAY INVOICE
@@ -484,11 +501,16 @@ export default function InvoiceDetailClient({
                     className="w-full"
                     disabled={submitting}
                     onClick={() =>
-                      handleAction(
-                        () => defaultInvoice({ invoiceId: invoice.id }),
-                        "Defaulting invoice...",
-                        "Unable to default invoice.",
-                      )
+                      requestConfirmation({
+                        label: "Default Invoice",
+                        invoiceId: invoice.id,
+                        fn: () =>
+                          handleAction(
+                            () => defaultInvoice({ invoiceId: invoice.id }),
+                            "Defaulting invoice...",
+                            "Unable to default invoice.",
+                          ),
+                      })
                     }
                   >
                     DEFAULT INVOICE


### PR DESCRIPTION
## Summary

Routes all four state-changing action buttons on the invoice detail page (`MARK GOODS SHIPPED`, `CONFIRM DELIVERY`, `REPAY INVOICE`, `DEFAULT INVOICE`) through the same `useConfirmDialogStore().request()` flow already used in `InvoiceCard.tsx`.

## Changes

- Imported `useConfirmDialogStore` in `InvoiceDetailClient.tsx`.
- Each action button's `onClick` now calls `requestConfirmation({ label, invoiceId, fn })` instead of calling `handleAction(...)` directly.
- The confirmation dialog component is already rendered globally via `providers.tsx`, so no additional rendering changes are needed.

## Problem

The invoice detail page had no confirmation step for irreversible on-chain actions. Users reaching the same actions from the detail page got no safety net that exists on the card view — the "irreversible on-chain action" warning was completely bypassed.

Closes #646

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>