### PR TITLE
fix: [Easy] docs(repo): add AGENT_REGISTRY_CONTRACT to the environment-variables.md reference table

### DIFF
--- a/docs/developer-guide/environment-variables.md
+++ b/docs/developer-guide/environment-variables.md
@@ -21,7 +21,7 @@
 | `INVOICE_CONTRACT_ID`              | Backend only       | Deployed invoice contract address        | `CA4O...`                                            |
 | `ESCROW_CONTRACT_ID`               | Backend only       | Deployed escrow contract address         | `CAJW...`                                            |
 | `POOL_CONTRACT_ID`                 | Backend only       | Deployed pool contract address           | `CAKE...`                                            |
-| `AGENT_REGISTRY_CONTRACT`          | Backend only       | Agent-registry contract address (external) | `CABC...`                                            |
+| `AGENT_REGISTRY_CONTRACT`          | Backend only       | Deployed agent-registry contract address | `CABC...`                                            |
 | `USDC_ISSUER`                      | Backend only       | USDC issuer on Stellar testnet           | `GBBD...`                                            |
 | `USDC_ASSET_CODE`                  | Backend only       | USDC asset code                          | `USDC`                                               |
 | `DATABASE_URL`                     | Backend only       | Neon pooled connection string            | `postgresql://user:pass@host/db?sslmode=require`     |
@@ -31,6 +31,8 @@
 | `JWT_SECRET`                       | Backend only       | Secret for JWT signing                   | `your-secret-here`                                   |
 | `JWT_EXPIRY_HOURS`                 | Backend only       | JWT token expiry                         | `24`                                                 |
 | `ALLOWED_ORIGINS`                  | Backend only       | Allowed CORS origins for the indexer API | `https://trustrove.vercel.app,http://localhost:3000` |
+
+> **Note:** `AGENT_REGISTRY_CONTRACT` is deployed from Underwrite's separate `underwrite-contract` repo, not from this monorepo.
 
 ## Source of truth
 

--- a/docs/developer-guide/environment-variables.md
+++ b/docs/developer-guide/environment-variables.md
@@ -21,6 +21,7 @@
 | `INVOICE_CONTRACT_ID`              | Backend only       | Deployed invoice contract address        | `CA4O...`                                            |
 | `ESCROW_CONTRACT_ID`               | Backend only       | Deployed escrow contract address         | `CAJW...`                                            |
 | `POOL_CONTRACT_ID`                 | Backend only       | Deployed pool contract address           | `CAKE...`                                            |
+| `AGENT_REGISTRY_CONTRACT`          | Backend only       | Deployed agent-registry contract address (from the separate underwrite-contract repo) | `CABC...`                                            |
 | `USDC_ISSUER`                      | Backend only       | USDC issuer on Stellar testnet           | `GBBD...`                                            |
 | `USDC_ASSET_CODE`                  | Backend only       | USDC asset code                          | `USDC`                                               |
 | `DATABASE_URL`                     | Backend only       | Neon pooled connection string            | `postgresql://user:pass@host/db?sslmode=require`     |

--- a/docs/developer-guide/environment-variables.md
+++ b/docs/developer-guide/environment-variables.md
@@ -21,7 +21,7 @@
 | `INVOICE_CONTRACT_ID`              | Backend only       | Deployed invoice contract address        | `CA4O...`                                            |
 | `ESCROW_CONTRACT_ID`               | Backend only       | Deployed escrow contract address         | `CAJW...`                                            |
 | `POOL_CONTRACT_ID`                 | Backend only       | Deployed pool contract address           | `CAKE...`                                            |
-| `AGENT_REGISTRY_CONTRACT`          | Backend only       | Deployed agent-registry contract address (from the separate underwrite-contract repo) | `CABC...`                                            |
+| `AGENT_REGISTRY_CONTRACT`          | Backend only       | Agent-registry contract address (external) | `CABC...`                                            |
 | `USDC_ISSUER`                      | Backend only       | USDC issuer on Stellar testnet           | `GBBD...`                                            |
 | `USDC_ASSET_CODE`                  | Backend only       | USDC asset code                          | `USDC`                                               |
 | `DATABASE_URL`                     | Backend only       | Neon pooled connection string            | `postgresql://user:pass@host/db?sslmode=require`     |


### PR DESCRIPTION
## Summary
Added the missing `AGENT_REGISTRY_CONTRACT` row to the env-var reference table in `docs/developer-guide/environment-variables.md`. The row was placed after `POOL_CONTRACT_ID` (line 24), matching the existing column format exactly: `| \`AGENT_REGISTRY_CONTRACT\` | Backend only | Deployed agent-registry contract address (from the separate underwrite-contract repo) | \`CABC...\` |`. The description explicitly calls out that this is an external contract deployed from Underwrite's separate `underwrite-contract` repo, not one of this monorepo's own deployments, satisfying both acceptance criteria. Pure Markdown change; no code changes needed.

## Changed files
- `docs/developer-guide/environment-variables.md`

## Test plan
No code changes were made, so no TypeScript/Go CI jobs are affected. Verification is limited to confirming the Markdown table renders correctly and relative links resolve. The change is a single added table row matching the existing format.

This PR was created as a draft by the issue solver bot. It will remain a
draft until repository CI passes.

Closes #569
