### PR TITLE
fix: [Medium] docs(indexer): document the missing auth/events/create-invoice/pool-snapshots endpoints

### DIFF
--- a/docs/developer-guide/indexer-api-reference.md
+++ b/docs/developer-guide/indexer-api-reference.md
@@ -95,3 +95,106 @@ Protocol-level aggregated statistics for the landing page.
   "pool_utilization_bps": 7500
 }
 ```
+
+## GET /auth
+
+Requests a SEP-10 authentication challenge for a Stellar account. No JWT required.
+
+**Query parameters:**
+
+- `account` — the Stellar public key to authenticate (required)
+
+**Response:**
+
+```json
+{
+  "transaction": "AAAAAgAAA...",
+  "network_passphrase": "Test SDF Network ; September 2015"
+}
+```
+
+## POST /auth
+
+Exchanges a signed SEP-10 challenge transaction for a JWT. No JWT required.
+
+**Request body:**
+
+```json
+{
+  "transaction": "AAAAAgAAA...signed..."
+}
+```
+
+**Response:**
+
+```json
+{
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "expires_in": 86400
+}
+```
+
+## POST /invoices
+
+Creates an off-chain/indexed invoice record. **Requires JWT** (`Authorization: Bearer <jwt>`).
+
+**Request body:**
+
+```json
+{
+  "buyer": "GBUYERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  "face_value": "1000.00",
+  "due_date": 1735689600,
+  "asset": "USDC"
+}
+```
+
+**Response (201):**
+
+```json
+{
+  "invoice_id": "a3f8c1d27e904b6a8d5f0139c2e7ab64f0d8c3b19a6e52f7b4c0d91e8a2735bc",
+  "transaction_hash": "abc123...",
+  "status": "SUCCESS"
+}
+```
+
+## GET /events
+
+Returns the most recent indexed Soroban events. No JWT required.
+
+**Query parameters:**
+
+- `limit` — number of events to return (default: 20)
+
+**Response:**
+
+```json
+[
+  {
+    "id": 1,
+    "event_id": "abc123...",
+    "contract_id": "CABC...",
+    "ledger": 12345,
+    "ledger_closed_at": 1748000000,
+    "event_type": "invoice_created",
+    "data": {}
+  }
+]
+```
+
+## GET /pool/snapshots
+
+Returns historical pool snapshots used for charts and trend analysis. No JWT required.
+
+**Response:**
+
+```json
+[
+  {
+    "timestamp": 1748000000,
+    "utilizationRateBps": 7500,
+    "totalYieldDistributed": "15000000000000"
+  }
+]
+```


### PR DESCRIPTION
## Summary
Documented the five missing endpoints in `docs/developer-guide/indexer-api-reference.md`:

- `## GET /auth` — SEP-10 challenge request, `account` query param, response with `transaction` and `network_passphrase`. No JWT required.
- `## POST /auth` — exchange signed SEP-10 challenge for JWT, request body with `transaction`, response with `token` and `expires_in`. No JWT required.
- `## POST /invoices` — create invoice, request body with `buyer`/`face_value`/`due_date`/`asset`, 201 response with `invoice_id`/`transaction_hash`/`status`. Requires JWT.
- `## GET /events` — list recent Soroban events, `limit` query param, bare-array response. No JWT required.
- `## GET /pool/snapshots` — historical pool snapshots, array response with `timestamp`/`utilizationRateBps`/`totalYieldDistributed`. No JWT required.

All sections match the existing terse style (short description, query/body params, JSON example) and call out JWT requirements per endpoint. Pure Markdown change; no code changes.

## Changed files
- `docs/developer-guide/indexer-api-reference.md`

## Test plan
No code changes were made, so no Go or TypeScript tests are affected. CI jobs (`Verify TypeScript Frontend & SDK` and `Verify Go Indexer & API`) should remain green since this is a documentation-only change. Local verification: confirm the relative links in the doc resolve and the Markdown renders correctly.

This PR was created as a draft by the issue solver bot. It will remain a
draft until repository CI passes.

Closes #568
