### PR TITLE
fix: [Easy] docs(indexer): add missing GET /pool/snapshots to openapi spec

### DIFF
--- a/docs/openapi/indexer.yaml
+++ b/docs/openapi/indexer.yaml
@@ -266,6 +266,22 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /pool/snapshots:
+    get:
+      tags: [Pool]
+      summary: Historical pool snapshots
+      description: Returns historical liquidity pool snapshots used for charts and trend analysis.
+      security: []
+      responses:
+        "200":
+          description: Pool snapshots
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/PoolSnapshot"
+
 components:
   securitySchemes:
     bearerAuth:
@@ -454,3 +470,24 @@ components:
           type: string
         deposit_count:
           type: integer
+
+    PoolSnapshot:
+      type: object
+      properties:
+        total_deposits:
+          type: string
+        total_funded:
+          type: string
+        available_liquidity:
+          type: string
+        utilization_rate_bps:
+          type: integer
+        total_yield_distributed:
+          type: string
+        active_invoice_count:
+          type: integer
+        total_shares:
+          type: string
+        updated_at:
+          type: string
+          format: date-time


### PR DESCRIPTION
## Summary
Added documentation for the previously undocumented `GET /pool/snapshots` endpoint in `docs/openapi/indexer.yaml`.

Changes:
1. Added a `/pool/snapshots` path entry under the `Pool` tag (after `/pool/position/{address}`), documenting a GET operation that returns an array of `PoolSnapshot` objects. The response is documented as an array because the frontend (`apps/web/lib/api.ts`'s `getPoolSnapshots`) fetches `PoolSnapshot[]` from this endpoint.
2. Added a `PoolSnapshot` schema to `components/schemas` matching the `pool_snapshots` table columns from `indexer/db/migrations/001_initial.sql`: `total_deposits`, `total_funded`, `available_liquidity`, `utilization_rate_bps`, `total_yield_distributed`, `active_invoice_count`, `total_shares`, and `updated_at` (formatted as date-time, matching Go's `time.Time` JSON serialization).

No code changes were made — this is a pure documentation (Markdown/YAML) change.

## Changed files
- `docs/openapi/indexer.yaml`

## Test plan
This is a documentation-only change (YAML). CI jobs to verify:
- `Verify TypeScript Frontend & SDK` — unaffected by YAML-only change, but should remain green.
- `Verify Go Indexer & API` — unaffected by YAML-only change, but should remain green.

Local verification: the `$ref: "#/components/schemas/PoolSnapshot"` reference resolves to the newly added schema in the same file, and the `Pool` tag is already defined in the `tags` section.

This PR was created as a draft by the issue solver bot. It will remain a
draft until repository CI passes.

Closes #567
