### PR TITLE
fix: [Easy] feat(web): add loading.tsx skeleton for /dashboard

### DIFF
--- a/apps/web/app/dashboard/loading.tsx
+++ b/apps/web/app/dashboard/loading.tsx
@@ -1,0 +1,98 @@
+import { SkeletonShimmer } from "@/components/shared/SkeletonLoader";
+
+export default function DashboardLoading() {
+  return (
+    <div className="space-y-8 py-4">
+      {/* Header */}
+      <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 border-b border-border/40 pb-5">
+        <div className="space-y-2">
+          <SkeletonShimmer className="h-6 w-72" />
+          <SkeletonShimmer className="h-3.5 w-96 max-w-full" />
+        </div>
+        <SkeletonShimmer className="h-10 w-40 rounded" />
+      </div>
+
+      {/* Stats Row */}
+      <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div
+            key={i}
+            className="bg-card border border-border rounded-lg p-4 space-y-2"
+          >
+            <SkeletonShimmer className="h-3 w-24" />
+            <SkeletonShimmer className="h-5 w-16" />
+            <SkeletonShimmer className="h-2.5 w-20" />
+          </div>
+        ))}
+      </div>
+
+      {/* Dashboard Grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
+        {/* Main Invoices Section */}
+        <div className="lg:col-span-8 space-y-6">
+          <SkeletonShimmer className="h-4 w-40" />
+
+          {/* Invoice table skeleton */}
+          <div className="bg-card border border-border rounded-lg overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-left border-collapse">
+                <thead>
+                  <tr className="border-b border-border bg-[#080c10]/40">
+                    {[1, 2, 3, 4, 5, 6].map((i) => (
+                      <th key={i} className="px-5 py-3.5">
+                        <SkeletonShimmer className="h-3 w-16" />
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border/30">
+                  {[1, 2, 3, 4, 5].map((i) => (
+                    <tr key={i}>
+                      {[1, 2, 3, 4, 5, 6].map((j) => (
+                        <td key={j} className="px-5 py-3.5">
+                          <SkeletonShimmer className="h-3.5 w-20" />
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {/* Activity timeline skeleton */}
+          <div className="bg-card border border-border rounded-lg p-5 space-y-4">
+            <div className="border-b border-border/40 pb-2">
+              <SkeletonShimmer className="h-3 w-44" />
+            </div>
+            <div className="space-y-3">
+              {[1, 2, 3, 4, 5].map((i) => (
+                <div
+                  key={i}
+                  className="flex justify-between items-start gap-4 p-2 border-b border-border/20 last:border-0"
+                >
+                  <div className="space-y-1.5 flex-1">
+                    <SkeletonShimmer className="h-3 w-32" />
+                    <SkeletonShimmer className="h-2.5 w-56" />
+                  </div>
+                  <SkeletonShimmer className="h-2.5 w-16 shrink-0" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Side Management Panel */}
+        <div className="lg:col-span-4 space-y-6">
+          <SkeletonShimmer className="h-4 w-40" />
+          <div className="bg-card/45 border border-dashed border-border rounded-lg p-6 py-20">
+            <div className="space-y-3">
+              <SkeletonShimmer className="h-3 w-48 mx-auto" />
+              <SkeletonShimmer className="h-3 w-64 mx-auto" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Added `apps/web/app/dashboard/loading.tsx` — a Next.js App Router route-level loading boundary for the `/dashboard` segment. It exports a default `DashboardLoading` component that renders a skeleton sized roughly to the dashboard's real content using the existing `SkeletonShimmer` from `@/components/shared/SkeletonLoader`. The skeleton mirrors the page structure: header with title/subtitle and action button, a 5-column stats row, the main invoice table (8-col grid), an activity timeline, and the side management panel (4-col grid). No new loading primitives were introduced; it reuses the existing `SkeletonShimmer` component, consistent with the existing `profile/loading.tsx` and `docs/loading.tsx` patterns.

## Changed files
- `apps/web/app/dashboard/loading.tsx`

## Test plan
1. `pnpm --filter web exec tsc --noEmit` — verify TypeScript is clean
2. `pnpm --filter web lint` — verify lint passes
3. `pnpm --filter web test` — verify tests pass
4. `pnpm build` — verify the build succeeds
5. Local dev verification: run `pnpm --filter web dev`, navigate to `/dashboard` with a throttled network (or artificial delay) to confirm the skeleton renders during navigation.

This PR was created as a draft by the issue solver bot. It will remain a
draft until repository CI passes.

Closes #556
