### PR TITLE
fix(web): preserve due dates and repair profile modal

### DIFF
--- a/apps/web/app/profile/page.test.tsx
+++ b/apps/web/app/profile/page.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ProfilePage from "@/app/profile/page";
+
+vi.mock("@/store/wallet", () => ({
+  useWalletStore: () => ({ connected: true, address: "GTESTADDRESS" }),
+}));
+
+vi.mock("@/hooks/useProfile", () => ({
+  useProfile: () => ({
+    profile: null,
+    isProfileLoading: false,
+    isVerified: false,
+    isVerifiedLoading: false,
+    register: vi.fn(),
+    isRegistering: false,
+    registerError: null,
+  }),
+}));
+
+vi.mock("@/components/shared/PageLayout", () => ({
+  PageLayout: ({ children }: { children: React.ReactNode }) => (
+    <main>{children}</main>
+  ),
+}));
+
+vi.mock("@/components/shared/ErrorBoundary", () => ({
+  ErrorBoundary: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("@/components/shared/WalletConnect", () => ({
+  WalletConnect: () => null,
+}));
+
+vi.mock("@/components/shared/TransactionPending", () => ({
+  TransactionPending: () => null,
+}));
+
+describe("Profile registration dialog", () => {
+  it("opens in an accessible fixed overlay", () => {
+    render(<ProfilePage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Register profile" }));
+
+    const dialog = screen.getByRole("dialog", {
+      name: "Register Business Metadata",
+    });
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("tabindex", "-1");
+    expect(dialog).toHaveClass("fixed", "inset-0", "z-50");
+    expect(
+      screen.getByRole("button", { name: "Close registration dialog" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -339,154 +339,176 @@ export default function ProfilePage() {
       {/* Registration Modal Dialog */}
       {showRegModal && (
         <ErrorBoundary context="RegistrationModal">
-          <div className="w-full max-w-lg bg-card border border-border rounded-lg p-6 relative shadow-[0_0_50px_rgba(0,212,170,0.05)]">
-            <button
-              onClick={() => setShowRegModal(false)}
-              className="absolute top-4 right-4 text-slate-500 hover:text-white font-bold font-mono text-xs uppercase"
+          <div
+            ref={modalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="registration-dialog-title"
+            tabIndex={-1}
+            className="fixed inset-0 z-50 flex items-end md:items-center justify-center bg-[#080c10]/95 backdrop-blur-sm p-0 md:p-4"
+            onClick={(event) => {
+              if (event.target === event.currentTarget) {
+                setShowRegModal(false);
+              }
+            }}
+          >
+            <div
+              className="w-full max-w-lg max-h-[92vh] md:max-h-[85vh] overflow-y-auto overscroll-contain bg-card border md:border-border rounded-t-2xl md:rounded-lg p-6 relative shadow-[0_0_50px_rgba(0,212,170,0.05)]"
+              onClick={(event) => event.stopPropagation()}
             >
-              [Close]
-            </button>
+              <button
+                onClick={() => setShowRegModal(false)}
+                aria-label="Close registration dialog"
+                className="absolute top-3 right-3 min-h-[44px] px-2 text-slate-500 hover:text-white font-bold font-mono text-xs uppercase"
+              >
+                [Close]
+              </button>
 
-            <div className="mb-6 border-b border-border/40 pb-3">
-              <h2 className="text-sm font-bold font-mono tracking-wider uppercase text-white flex items-center gap-1.5">
-                <Building2 className="w-4 h-4 text-primary" />
-                Register Business Metadata
-              </h2>
-              <p className="text-[10px] text-slate-500 font-mono mt-0.5">
-                Input your company credentials. This metadata maps to your
-                wallet address on-chain.
-              </p>
-            </div>
-
-            <form
-              onSubmit={handleRegisterSubmit}
-              className="space-y-4 font-mono text-xs"
-            >
-              {/* Role Toggle Selector */}
-              <div className="space-y-2">
-                <label className="block text-[10px] font-bold text-slate-500 uppercase tracking-wider">
-                  Select On-Chain Business Role
-                </label>
-                <div className="grid grid-cols-2 gap-2">
-                  <button
-                    type="button"
-                    onClick={() => setRegRole("issuer")}
-                    className={`py-2 px-3 border rounded text-center transition-all ${
-                      regRole === "issuer"
-                        ? "border-primary bg-primary/5 text-primary font-bold"
-                        : "border-border bg-transparent text-slate-400 hover:text-white hover:bg-slate-900/40"
-                    }`}
-                  >
-                    SME / Issuer
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setRegRole("buyer")}
-                    className={`py-2 px-3 border rounded text-center transition-all ${
-                      regRole === "buyer"
-                        ? "border-primary bg-primary/5 text-primary font-bold"
-                        : "border-border bg-transparent text-slate-400 hover:text-white hover:bg-slate-900/40"
-                    }`}
-                  >
-                    Obligor / Buyer
-                  </button>
-                </div>
+              <div className="mb-6 border-b border-border/40 pb-3">
+                <h2
+                  id="registration-dialog-title"
+                  className="text-sm font-bold font-mono tracking-wider uppercase text-white flex items-center gap-1.5 pr-16"
+                >
+                  <Building2 className="w-4 h-4 text-primary" />
+                  Register Business Metadata
+                </h2>
+                <p className="text-[10px] text-slate-500 font-mono mt-0.5">
+                  Input your company credentials. This metadata maps to your
+                  wallet address on-chain.
+                </p>
               </div>
 
-              {/* Tax ID & Country */}
-              <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-1">
+              <form
+                onSubmit={handleRegisterSubmit}
+                className="space-y-4 font-mono text-xs"
+              >
+                {/* Role Toggle Selector */}
+                <div className="space-y-2">
                   <label className="block text-[10px] font-bold text-slate-500 uppercase tracking-wider">
-                    Tax ID / Registration No.
+                    Select On-Chain Business Role
                   </label>
-                  <div className="relative">
-                    <FileText className="absolute left-3 top-2.5 w-4 h-4 text-slate-500" />
-                    <input
-                      type="text"
-                      required
-                      placeholder="e.g. EU123456789"
-                      className="w-full bg-[#080c10] border border-border rounded pl-10 pr-3 py-2 text-white placeholder-slate-600 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary"
-                      value={taxId}
-                      onChange={(e) => setTaxId(e.target.value)}
-                    />
+                  <div className="grid grid-cols-2 gap-2">
+                    <button
+                      type="button"
+                      onClick={() => setRegRole("issuer")}
+                      className={`py-2 px-3 border rounded text-center transition-all ${
+                        regRole === "issuer"
+                          ? "border-primary bg-primary/5 text-primary font-bold"
+                          : "border-border bg-transparent text-slate-400 hover:text-white hover:bg-slate-900/40"
+                      }`}
+                    >
+                      SME / Issuer
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setRegRole("buyer")}
+                      className={`py-2 px-3 border rounded text-center transition-all ${
+                        regRole === "buyer"
+                          ? "border-primary bg-primary/5 text-primary font-bold"
+                          : "border-border bg-transparent text-slate-400 hover:text-white hover:bg-slate-900/40"
+                      }`}
+                    >
+                      Obligor / Buyer
+                    </button>
                   </div>
                 </div>
 
+                {/* Tax ID & Country */}
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-1">
+                    <label className="block text-[10px] font-bold text-slate-500 uppercase tracking-wider">
+                      Tax ID / Registration No.
+                    </label>
+                    <div className="relative">
+                      <FileText className="absolute left-3 top-2.5 w-4 h-4 text-slate-500" />
+                      <input
+                        type="text"
+                        required
+                        placeholder="e.g. EU123456789"
+                        className="w-full bg-[#080c10] border border-border rounded pl-10 pr-3 py-2 text-white placeholder-slate-600 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary"
+                        value={taxId}
+                        onChange={(e) => setTaxId(e.target.value)}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="space-y-1">
+                    <label className="block text-[10px] font-bold text-slate-500 uppercase tracking-wider">
+                      Country of Incorporation
+                    </label>
+                    <div className="relative">
+                      <Globe className="absolute left-3 top-2.5 w-4 h-4 text-slate-500" />
+                      <input
+                        type="text"
+                        required
+                        placeholder="e.g. Germany"
+                        className="w-full bg-[#080c10] border border-border rounded pl-10 pr-3 py-2 text-white placeholder-slate-600 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary"
+                        value={country}
+                        onChange={(e) => setCountry(e.target.value)}
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                {/* Website URL */}
                 <div className="space-y-1">
                   <label className="block text-[10px] font-bold text-slate-500 uppercase tracking-wider">
-                    Country of Incorporation
+                    Corporate Website URL (Optional)
                   </label>
                   <div className="relative">
                     <Globe className="absolute left-3 top-2.5 w-4 h-4 text-slate-500" />
                     <input
-                      type="text"
-                      required
-                      placeholder="e.g. Germany"
+                      type="url"
+                      placeholder="e.g. https://acme.corp"
                       className="w-full bg-[#080c10] border border-border rounded pl-10 pr-3 py-2 text-white placeholder-slate-600 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary"
-                      value={country}
-                      onChange={(e) => setCountry(e.target.value)}
+                      value={website}
+                      onChange={(e) => setWebsite(e.target.value)}
                     />
                   </div>
                 </div>
-              </div>
 
-              {/* Website URL */}
-              <div className="space-y-1">
-                <label className="block text-[10px] font-bold text-slate-500 uppercase tracking-wider">
-                  Corporate Website URL (Optional)
-                </label>
-                <div className="relative">
-                  <Globe className="absolute left-3 top-2.5 w-4 h-4 text-slate-500" />
-                  <input
-                    type="url"
-                    placeholder="e.g. https://acme.corp"
-                    className="w-full bg-[#080c10] border border-border rounded pl-10 pr-3 py-2 text-white placeholder-slate-600 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary"
-                    value={website}
-                    onChange={(e) => setWebsite(e.target.value)}
-                  />
-                </div>
-              </div>
+                {/* Warnings and errors */}
+                {(localError || registerError) && (
+                  <div className="p-3 rounded bg-rose-500/10 border border-rose-500/20 text-rose-400 text-[11px] flex items-start gap-2">
+                    <ShieldAlert className="w-4 h-4 shrink-0 mt-0.5" />
+                    <span>
+                      {localError ||
+                        (registerError as any)?.message ||
+                        "Failed to submit registration"}
+                    </span>
+                  </div>
+                )}
 
-              {/* Warnings and errors */}
-              {(localError || registerError) && (
-                <div className="p-3 rounded bg-rose-500/10 border border-rose-500/20 text-rose-400 text-[11px] flex items-start gap-2">
-                  <ShieldAlert className="w-4 h-4 shrink-0 mt-0.5" />
+                <div className="bg-[#080c10] border border-amber-500/20 p-3 rounded text-[10px] text-amber-500 leading-normal flex items-start gap-1.5">
+                  <Lock className="w-3.5 h-3.5 shrink-0 mt-0.5" />
                   <span>
-                    {localError ||
-                      (registerError as any)?.message ||
-                      "Failed to submit registration"}
+                    Signing this registration requires Freighter authorization.
+                    You will submit a Soroban write transaction, which
+                    whitelists your wallet address and locks your business
+                    credentials.
                   </span>
                 </div>
-              )}
 
-              <div className="bg-[#080c10] border border-amber-500/20 p-3 rounded text-[10px] text-amber-500 leading-normal flex items-start gap-1.5">
-                <Lock className="w-3.5 h-3.5 shrink-0 mt-0.5" />
-                <span>
-                  Signing this registration requires Freighter authorization.
-                  You will submit a Soroban write transaction, which whitelists
-                  your wallet address and locks your business credentials.
-                </span>
-              </div>
-
-              {/* Buttons */}
-              <div className="flex gap-2 pt-2">
-                <button
-                  type="button"
-                  onClick={() => setShowRegModal(false)}
-                  className="flex-1 border border-border bg-transparent hover:bg-slate-900 text-slate-400 font-bold uppercase py-2.5 rounded"
-                  disabled={isRegistering}
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  className="flex-1 bg-primary hover:bg-primary-hover text-black font-bold uppercase py-2.5 rounded shadow-[0_0_15px_rgba(0,212,170,0.15)] flex items-center justify-center gap-1.5"
-                  disabled={isRegistering}
-                >
-                  {isRegistering ? "Signing..." : "Register Profile"}
-                </button>
-              </div>
-            </form>
+                {/* Buttons */}
+                <div className="flex gap-2 pt-2">
+                  <button
+                    type="button"
+                    onClick={() => setShowRegModal(false)}
+                    className="flex-1 border border-border bg-transparent hover:bg-slate-900 text-slate-400 font-bold uppercase py-2.5 rounded"
+                    disabled={isRegistering}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    className="flex-1 bg-primary hover:bg-primary-hover text-black font-bold uppercase py-2.5 rounded shadow-[0_0_15px_rgba(0,212,170,0.15)] flex items-center justify-center gap-1.5"
+                    disabled={isRegistering}
+                  >
+                    {isRegistering ? "Signing..." : "Register Profile"}
+                  </button>
+                </div>
+              </form>
+            </div>
           </div>
         </ErrorBoundary>
       )}

--- a/apps/web/components/ui/date-picker.test.tsx
+++ b/apps/web/components/ui/date-picker.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { DatePicker } from "@/components/ui/date-picker";
+
+const calendarState = vi.hoisted(() => ({
+  selectedDate: new Date(2026, 0, 1),
+}));
+
+vi.mock("@/components/ui/calendar", () => ({
+  Calendar: ({ onSelect }: { onSelect: (date: Date) => void }) => (
+    <button onClick={() => onSelect(calendarState.selectedDate)}>
+      Choose date
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+const originalTimezone = process.env.TZ;
+
+afterAll(() => {
+  if (originalTimezone === undefined) {
+    delete process.env.TZ;
+  } else {
+    process.env.TZ = originalTimezone;
+  }
+});
+
+describe("DatePicker", () => {
+  it.each([
+    ["America/Los_Angeles", "2026-08-30T00:30:00-07:00"],
+    ["Pacific/Auckland", "2026-08-30T00:30:00+12:00"],
+  ])("preserves the selected calendar day in %s", (timezone, timestamp) => {
+    process.env.TZ = timezone;
+    calendarState.selectedDate = new Date(timestamp);
+    const onChange = vi.fn();
+
+    render(<DatePicker onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "Choose date" }));
+
+    expect(onChange).toHaveBeenCalledWith("2026-08-30");
+  });
+
+  it("parses a stored date as a local calendar date", () => {
+    process.env.TZ = "America/Los_Angeles";
+
+    render(<DatePicker value="2026-08-30" onChange={vi.fn()} />);
+
+    expect(
+      screen.getByRole("button", { name: /August 30th, 2026/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/ui/date-picker.tsx
+++ b/apps/web/components/ui/date-picker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { format } from "date-fns";
+import { format, parse } from "date-fns";
 import { Calendar as CalendarIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
@@ -28,7 +28,9 @@ export function DatePicker({
 }: DatePickerProps) {
   const [open, setOpen] = React.useState(false);
 
-  const selectedDate = value ? new Date(value) : undefined;
+  const selectedDate = value
+    ? parse(value, "yyyy-MM-dd", new Date())
+    : undefined;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -51,7 +53,7 @@ export function DatePicker({
           selected={selectedDate}
           onSelect={(date) => {
             if (date) {
-              onChange(date.toISOString().split("T")[0]);
+              onChange(format(date, "yyyy-MM-dd"));
               setOpen(false);
             }
           }}

--- a/apps/web/e2e/profile-registration.spec.ts
+++ b/apps/web/e2e/profile-registration.spec.ts
@@ -31,7 +31,11 @@ test.describe("Profile Registration & Verification - Happy Path", () => {
     await page.getByRole("button", { name: /Register profile/i }).click();
 
     // Modal should be visible with the registration form
-    await expect(page.getByText(/Register Business Metadata/i)).toBeVisible();
+    const dialog = page.getByRole("dialog", {
+      name: /Register Business Metadata/i,
+    });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute("aria-modal", "true");
     await expect(
       page.getByText(/Select On-Chain Business Role/i),
     ).toBeVisible();


### PR DESCRIPTION
## Description

Fixes the two remaining assigned frontend issues after #710 was merged.

### Changes

- parse stored invoice due dates as local `yyyy-MM-dd` values
- serialize selected dates with local calendar fields instead of UTC conversion
- cover selection in negative and positive UTC offsets, plus local display parsing
- render profile registration in the same responsive fixed overlay pattern as other app dialogs
- attach the existing focus trap and add dialog labeling, backdrop dismissal, mobile scroll containment, and an accessible close control
- add unit and end-to-end assertions for the modal contract

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Accessibility improvement

## Testing

- `pnpm --filter web test` — 50 test files passed, 363 tests passed
- targeted date-picker and profile tests — 4 tests passed
- `pnpm --filter web lint` — completed with existing warnings only
- `git diff --check upstream/main...HEAD` — passed

## Reviewer Focus Areas

- local calendar behavior across UTC offsets
- responsive modal overlay and focus behavior

Closes #651
Closes #652
