### PR TITLE
Implement toUsdc and fromUsdc helpers in SDK

### DIFF
--- a/packages/sdk/src/amounts.test.ts
+++ b/packages/sdk/src/amounts.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { toUsdc, fromUsdc } from "./amounts.js";
+
+describe("toUsdc", () => {
+  it('converts 1 USDC (10_000_000 stroops) to "1.00"', () => {
+    expect(toUsdc(BigInt(10_000_000))).toBe("1.00");
+  });
+
+  it("converts 1000.50 USDC", () => {
+    expect(toUsdc(BigInt(10_005_000_000))).toBe("1000.50");
+  });
+
+  it('converts zero stroops to "0.00"', () => {
+    expect(toUsdc(0n)).toBe("0.00");
+  });
+
+  it("converts a small fractional amount", () => {
+    // 0.01 USDC = 100_000 stroops
+    expect(toUsdc(BigInt(100_000))).toBe("0.01");
+  });
+
+  it('converts 1 stroop to "0.00" (below display precision)', () => {
+    expect(toUsdc(1n)).toBe("0.00");
+  });
+
+  it("handles large values", () => {
+    // 1_000_000 USDC
+    expect(toUsdc(BigInt(10_000_000_000_000))).toBe("1000000.00");
+  });
+
+  it("handles negative amounts", () => {
+    expect(toUsdc(BigInt(-10_000_000))).toBe("-1.00");
+  });
+
+  it("handles negative fractional amounts", () => {
+    expect(toUsdc(BigInt(-10_005_000_000))).toBe("-1000.50");
+  });
+
+  it("rounds down sub-cent remainders", () => {
+    // 0.009 USDC = 90_000 stroops → "0.00" (displayed as 0.00)
+    expect(toUsdc(BigInt(90_000))).toBe("0.00");
+    // 0.014 USDC = 140_000 stroops → "0.01"
+    expect(toUsdc(BigInt(140_000))).toBe("0.01");
+  });
+});
+
+describe("fromUsdc", () => {
+  it('parses "1000.50" to 10_005_000_000 stroops', () => {
+    expect(fromUsdc("1000.50")).toBe(BigInt(10_005_000_000));
+  });
+
+  it('parses "1" to 10_000_000 stroops', () => {
+    expect(fromUsdc("1")).toBe(BigInt(10_000_000));
+  });
+
+  it('parses "0.01" to 100_000 stroops', () => {
+    expect(fromUsdc("0.01")).toBe(BigInt(100_000));
+  });
+
+  it('parses "0" to 0n', () => {
+    expect(fromUsdc("0")).toBe(0n);
+  });
+
+  it("parses an integer with no decimal point", () => {
+    expect(fromUsdc("42")).toBe(BigInt(420_000_000));
+  });
+
+  it("truncates extra fractional digits beyond 7", () => {
+    // "0.00000001" has 8 fractional digits; the 8th is truncated
+    expect(fromUsdc("0.00000001")).toBe(0n);
+    // "0.0000001" is exactly 1 stroop
+    expect(fromUsdc("0.0000001")).toBe(1n);
+  });
+
+  it("pads fractional digits shorter than 7", () => {
+    // "0.1" → 0.1000000 → 1_000_000
+    expect(fromUsdc("0.1")).toBe(BigInt(1_000_000));
+  });
+
+  it("handles negative amounts", () => {
+    expect(fromUsdc("-1000.50")).toBe(BigInt(-10_005_000_000));
+  });
+
+  it("handles whitespace around the input", () => {
+    expect(fromUsdc("  42.00  ")).toBe(BigInt(420_000_000));
+  });
+
+  it("throws on invalid input", () => {
+    expect(() => fromUsdc("abc")).toThrow("Invalid USDC amount");
+    expect(() => fromUsdc("1.2.3")).toThrow("Invalid USDC amount");
+    expect(() => fromUsdc("")).toThrow("Invalid USDC amount");
+  });
+});
+
+describe("round-trip consistency", () => {
+  const cases: [bigint, string][] = [
+    [0n, "0.00"],
+    [100_000n, "0.01"],
+    [10_000_000n, "1.00"],
+    [10_005_000_000n, "1000.50"],
+    [10_000_000_000_000n, "1000000.00"],
+  ];
+
+  it.each(cases)(
+    "fromUsdc(toUsdc(%s)) preserves the stroop value for %s USDC",
+    (stroops, _expected) => {
+      const formatted = toUsdc(stroops);
+      const roundTripped = fromUsdc(formatted);
+      expect(roundTripped).toBe(stroops);
+    },
+  );
+});

--- a/packages/sdk/src/amounts.ts
+++ b/packages/sdk/src/amounts.ts
@@ -1,0 +1,70 @@
+/**
+ * Number of stroops per whole USDC unit (10^7 = 1 USDC).
+ *
+ * Stellar on-chain amounts are u128 integers denominated in stroops.
+ * All SDK financial methods accept and return `bigint` in stroops.
+ */
+const STROOPS_PER_USDC = 10_000_000;
+
+/**
+ * Converts a stroop-denominated bigint to a human-readable USDC string
+ * with exactly two decimal places.
+ *
+ * @param stroops - The amount in stroops (10^7 = 1 USDC).
+ * @returns A formatted string, e.g. `"1.00"`, `"1000.50"`, `"0.01"`.
+ *
+ * @example
+ * ```ts
+ * toUsdc(BigInt(10_000_000)); // "1.00"
+ * toUsdc(BigInt(10_005_000_000)); // "1000.50"
+ * toUsdc(0n); // "0.00"
+ * ```
+ */
+export function toUsdc(stroops: bigint): string {
+  const whole = stroops / BigInt(STROOPS_PER_USDC);
+  const fraction = stroops % BigInt(STROOPS_PER_USDC);
+
+  // Absolute value for formatting; track sign separately.
+  const negative = stroops < 0n;
+  const absWhole = negative ? -whole : whole;
+  const absFraction = negative ? -fraction : fraction;
+
+  const fractionStr = absFraction.toString().padStart(7, "0").slice(0, 2);
+  return `${negative ? "-" : ""}${absWhole.toString()}.${fractionStr}`;
+}
+
+/**
+ * Parses a USDC decimal string into a stroop-denominated bigint.
+ *
+ * Accepts integers (`"100"`) and decimals with up to 7 fractional digits
+ * (`"1000.50"`, `"0.0000001"`). Extra fractional digits beyond 7 are
+ * truncated (not rounded).
+ *
+ * @param usdc - A decimal string, e.g. `"1000.50"`.
+ * @returns The amount in stroops as a bigint.
+ * @throws {Error} If the input is not a valid decimal number.
+ *
+ * @example
+ * ```ts
+ * fromUsdc("1000.50"); // 10005000000n
+ * fromUsdc("1"); // 10000000n
+ * fromUsdc("0.01"); // 100000n
+ * ```
+ */
+export function fromUsdc(usdc: string): bigint {
+  const trimmed = usdc.trim();
+
+  if (!/^-?\d+(\.\d+)?$/.test(trimmed)) {
+    throw new Error(`Invalid USDC amount: "${usdc}"`);
+  }
+
+  const negative = trimmed.startsWith("-");
+  const magnitude = negative ? trimmed.slice(1) : trimmed;
+
+  const [intPart, fracPart = ""] = magnitude.split(".");
+  // Pad or truncate fractional part to exactly 7 digits (stroops precision).
+  const paddedFrac = fracPart.padEnd(7, "0").slice(0, 7);
+
+  const stroops = BigInt(intPart + paddedFrac);
+  return negative ? -stroops : stroops;
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./config.js";
+export * from "./amounts.js";
 export * from "./base.js";
 export * from "./types/index.js";
 export * from "./clients/registry.js";


### PR DESCRIPTION
## Summary

Implements `toUsdc`/`fromUsdc` in `packages/sdk/src/amounts.ts`, matching the documented signatures in `docs/developer-guide/sdk-reference.md` lines 229–240. Both functions are exported from `@trusttrove/sdk`.

Closes #570 

## Changes

- **`packages/sdk/src/amounts.ts`** — New module with two pure functions:
  - `toUsdc(stroops: bigint): string` — converts stroop-denominated bigints to human-readable strings with exactly two decimal places (e.g. `BigInt(10_000_000)` → `"1.00"`)
  - `fromUsdc(usdc: string): bigint` — parses decimal strings to stroop bigints with up to 7 fractional digits, truncating extra precision (e.g. `"1000.50"` → `BigInt(10_005_000_000)`)
- **`packages/sdk/src/index.ts`** — Re-exports `./amounts.js`
- **`packages/sdk/src/amounts.test.ts`** — 24 vitest cases covering both directions, edge cases (zero, 1 stroop, large values), negatives, rounding behavior, and round-trip consistency

## What's NOT in this PR

Refactoring `apps/web/lib/assets.ts` to delegate to the new SDK functions is intentionally scoped out as a follow-up, per the issue's suggestion.

## Verification

- `pnpm --filter @trusttrove/sdk build` ✅
- `pnpm --filter @trusttrove/sdk test` ✅ (154 tests, 21 files)