### PR TITLE
test: add keyboard-navigation tests for profile registration modal focus trap

### DIFF
--- a/apps/web/app/profile/page.test.tsx
+++ b/apps/web/app/profile/page.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import ProfilePage from "@/app/profile/page";
 
@@ -57,5 +58,106 @@ describe("Profile registration dialog", () => {
     expect(
       screen.getByRole("button", { name: "Close registration dialog" }),
     ).toBeInTheDocument();
+  });
+
+  it("traps Tab and Shift+Tab focus within the modal", async () => {
+    const user = userEvent.setup();
+    render(<ProfilePage />);
+
+    const openButton = screen.getByRole("button", {
+      name: "Register profile",
+    });
+    await user.click(openButton);
+
+    const dialog = screen.getByRole("dialog", {
+      name: "Register Business Metadata",
+    });
+
+    // Collect all focusable elements inside the modal
+    const focusableSelector = [
+      "button:not([disabled])",
+      "input:not([disabled])",
+      "select:not([disabled])",
+      "textarea:not([disabled])",
+      '[tabindex]:not([tabindex="-1"])',
+    ].join(",");
+    const focusableElements = Array.from(
+      dialog.querySelectorAll<HTMLElement>(focusableSelector),
+    ).filter((el) => {
+      const style = window.getComputedStyle(el);
+      return style.display !== "none" && style.visibility !== "hidden";
+    });
+
+    expect(focusableElements.length).toBeGreaterThanOrEqual(2);
+
+    // Focus should start inside the modal (useFocusTrap moves focus to first element)
+    expect(dialog).toContainElement(document.activeElement as HTMLElement);
+
+    // Tab forward through all focusable elements and beyond — should cycle back
+    for (let i = 0; i < focusableElements.length + 2; i++) {
+      await user.tab();
+      expect(dialog).toContainElement(document.activeElement as HTMLElement);
+    }
+
+    // Tab backward through all focusable elements and beyond — should cycle back
+    for (let i = 0; i < focusableElements.length + 2; i++) {
+      await user.tab({ shift: true });
+      expect(dialog).toContainElement(document.activeElement as HTMLElement);
+    }
+  });
+
+  it("restores focus to the trigger button when modal closes via Escape", async () => {
+    const user = userEvent.setup();
+    render(<ProfilePage />);
+
+    const openButton = screen.getByRole("button", {
+      name: "Register profile",
+    });
+    await user.click(openButton);
+
+    // Escape should close the modal (useFocusTrap calls onEscape)
+    await user.keyboard("{Escape}");
+
+    // The dialog should no longer be in the document
+    expect(
+      screen.queryByRole("dialog", {
+        name: "Register Business Metadata",
+      }),
+    ).not.toBeInTheDocument();
+
+    // useFocusTrap restores focus via requestAnimationFrame, so flush it
+    await new Promise((r) => requestAnimationFrame(r));
+
+    // Focus should return to the element that opened the modal
+    expect(openButton).toHaveFocus();
+  });
+
+  it("restores focus to the trigger button when modal closes via close button", async () => {
+    const user = userEvent.setup();
+    render(<ProfilePage />);
+
+    const openButton = screen.getByRole("button", {
+      name: "Register profile",
+    });
+    await user.click(openButton);
+
+    // Click the close button
+    const closeButton = screen.getByRole("button", {
+      name: "Close registration dialog",
+    });
+    await user.click(closeButton);
+
+    // The dialog should no longer be in the document
+    expect(
+      screen.queryByRole("dialog", {
+        name: "Register Business Metadata",
+      }),
+    ).not.toBeInTheDocument();
+
+    // useFocusTrap restores focus via requestAnimationFrame, so flush it
+    await new Promise((r) => requestAnimationFrame(r));
+
+    // Focus should return to the element that opened the modal
+    expect(openButton).toHaveFocus();
   });
 });


### PR DESCRIPTION
## Overview

This PR addresses issue #664 by adding comprehensive keyboard-navigation tests for the profile registration modal's focus trap behavior.

### Investigation findings

The `useFocusTrap` ref (`modalRef`) is **already attached** to the correct outer container element of the registration modal (verified via git history — added in commit `ad25224`). The ref is attached to the `<div>` with `role="dialog"`, `aria-modal="true"`, and `tabIndex={-1}`, which wraps all focusable elements within the modal (close button, role toggle buttons, form inputs, cancel/register buttons).

However, there were **no tests** verifying that the focus trap actually works for keyboard users — meaning a regression could silently break keyboard accessibility on this core registration flow.

### What changed

**`apps/web/app/profile/page.test.tsx`** — Added 3 new tests:

1. **`traps Tab and Shift+Tab focus within the modal`** — Simulates repeated Tab and Shift+Tab presses (more than enough to cycle past the last/first focusable element) and asserts that `document.activeElement` always remains within the dialog container. This proves the focus trap holds in both forward and backward directions.

2. **`restores focus to the trigger button when modal closes via Escape`** — Opens the modal, presses Escape to close it, and asserts focus returns to the "Register profile" button that triggered the modal.

3. **`restores focus to the trigger button when modal closes via close button`** — Same flow but using the close button instead of Escape.

These tests use `@testing-library/user-event` (already used in the codebase) to simulate real keyboard navigation.

### Related overlay-wrapper issue

The issue mentions a "related UX issue for the same modal" about a missing overlay wrapper. Based on the current DOM structure, the modal's outer `<div>` (with `ref={modalRef}`) serves as both the overlay backdrop and the focus-trap container. If that related issue is resolved later with a separate overlay element, the ref placement may need re-checking to ensure it still wraps all focusable elements.

### Verification

- ✅ **Tests**: All 53 test files pass (389 tests), including 3 new keyboard-navigation tests
- ✅ **Lint**: `next lint` passes (no new warnings)
- ✅ **TypeScript**: `tsc --noEmit` passes (only pre-existing `@trusttrove/sdk` and `defaultedAt` errors remain)

### Pre-existing failures (intentionally untouched)

- `@trusttrove/sdk` module resolution errors in `tsc --noEmit` — pre-existing workspace issue
- `defaultedAt` does not exist in `Partial<Invoice>` type error in `InvoiceStatusTimeline.test.tsx` — pre-existing

Closes #664

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>