### PR TITLE
docs(indexer): fix GET /auth query param name from account to address

### DIFF
--- a/docs/developer-guide/indexer-api-reference.md
+++ b/docs/developer-guide/indexer-api-reference.md
@@ -102,7 +102,7 @@ Requests a SEP-10 authentication challenge for a Stellar account. No JWT require
 
 **Query parameters:**
 
-- `account` — the Stellar public key to authenticate (required)
+- `address` — the Stellar public key to authenticate (required)
 
 **Response:**
 

--- a/docs/openapi/indexer.yaml
+++ b/docs/openapi/indexer.yaml
@@ -7,7 +7,7 @@ info:
 
     ## SEP-10 authentication flow
 
-    1. The frontend calls `GET /auth?account=<stellar_public_key>` to request an authentication challenge.
+    1. The frontend calls `GET /auth?address=<stellar_public_key>` to request an authentication challenge.
     2. The client signs the returned SEP-10 challenge transaction with Freighter or another Stellar wallet.
     3. The client sends the signed challenge to `POST /auth`.
     4. The indexer validates the signed challenge and returns a JWT.
@@ -55,7 +55,7 @@ paths:
       description: Returns a SEP-10 challenge transaction for the supplied Stellar account.
       security: []
       parameters:
-        - name: account
+        - name: address
           in: query
           required: true
           schema:


### PR DESCRIPTION
# docs(indexer): fix GET /auth query parameter in OpenAPI spec

Closes #564

## Summary

Fixes the `GET /auth` query parameter name in the OpenAPI specification to match the actual indexer API implementation.

## Changes

* Renamed the `GET /auth` query parameter from `account` to `address`
* Verified the parameter matches `HandleGetAuth` in `indexer/api/handlers.go`
* Confirmed it matches the frontend request used by `fetchChallenge`
* Spot-checked the surrounding `/auth` documentation for consistency

## Verification

* [x] `GET /auth` uses `address` in the OpenAPI spec
* [x] Parameter matches the actual handler behavior
* [x] No application code changes required
