### PR TITLE
fix(web): handle wallet address copy failures

### DIFF
--- a/apps/web/app/lp/loading.tsx
+++ b/apps/web/app/lp/loading.tsx
@@ -1,4 +1,8 @@
-import { SkeletonShimmer, PoolStatsPanelSkeleton, LPPositionCardSkeleton } from "@/components/shared/SkeletonLoader";
+import {
+  SkeletonShimmer,
+  PoolStatsPanelSkeleton,
+  LPPositionCardSkeleton,
+} from "@/components/shared/SkeletonLoader";
 
 export default function LPLoading() {
   return (

--- a/apps/web/app/marketplace/loading.tsx
+++ b/apps/web/app/marketplace/loading.tsx
@@ -1,4 +1,7 @@
-import { SkeletonShimmer, InvoiceTableSkeleton } from "@/components/shared/SkeletonLoader";
+import {
+  SkeletonShimmer,
+  InvoiceTableSkeleton,
+} from "@/components/shared/SkeletonLoader";
 
 export default function MarketplaceLoading() {
   return (

--- a/apps/web/components/shared/WalletConnect.test.tsx
+++ b/apps/web/components/shared/WalletConnect.test.tsx
@@ -170,4 +170,29 @@ describe("WalletConnect", () => {
     fireEvent.click(screen.getByLabelText(/Copy wallet address/i));
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(address);
   });
+
+  it("shows an error when copying the wallet address fails", async () => {
+    const address = "GACR43ILX6H4PGAOO5QKSZLU4ZJMGT3E66EAUDPLM5J6YTP4Y3PSHWGB";
+    vi.mocked(useWallet).mockReturnValue({
+      connected: true,
+      loading: false,
+      address,
+      error: null,
+      connectWallet: vi.fn(),
+      disconnectWallet: vi.fn(),
+    } as any);
+    vi.mocked(isFreighterInstalled).mockResolvedValue(true);
+    vi.mocked(navigator.clipboard.writeText).mockRejectedValueOnce(
+      new Error("Clipboard permission denied"),
+    );
+
+    render(<WalletConnect />);
+
+    const copyButton = await screen.findByLabelText(/Copy wallet address/i);
+    fireEvent.click(copyButton);
+
+    expect(
+      await screen.findByText(/couldn't copy wallet address/i),
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/web/components/shared/WalletConnect.tsx
+++ b/apps/web/components/shared/WalletConnect.tsx
@@ -35,6 +35,7 @@ export function WalletConnect() {
   const network = useWalletStore((s) => s.network);
   const [installed, setInstalled] = useState<boolean | null>(null);
   const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState<string | null>(null);
   const [switchingNetwork, setSwitchingNetwork] = useState(false);
   const [networkSwitchError, setNetworkSwitchError] = useState<string | null>(
     null,
@@ -46,9 +47,16 @@ export function WalletConnect() {
 
   const handleCopy = async () => {
     if (!address) return;
-    await navigator.clipboard.writeText(address);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+
+    try {
+      setCopyError(null);
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+      setCopyError("Couldn't copy wallet address. Please try again.");
+    }
   };
 
   const handleSwitchToTestnet = async () => {
@@ -207,6 +215,16 @@ export function WalletConnect() {
           <span className="truncate max-w-xs">
             You cancelled the connection request
           </span>
+        </div>
+      )}
+
+      {copyError && (
+        <div
+          role="alert"
+          className="flex items-center gap-1.5 text-xs text-rose-400 bg-rose-500/10 border border-rose-500/20 rounded-md px-2.5 py-1"
+        >
+          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+          <span>{copyError}</span>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- catch clipboard write failures in `WalletConnect`
- show an accessible inline error message when copying the wallet address fails
- add regression coverage for rejected clipboard writes

## Validation
- `pnpm --dir apps/web test -- components/shared/WalletConnect.test.tsx`
- `pnpm --dir apps/web lint`
- `pnpm --filter @trusttrove/sdk build && pnpm --dir apps/web exec tsc --noEmit`

Closes #654