### PR TITLE
fix(web): add reload escape to error boundary

### DIFF
--- a/apps/web/app/lp/loading.tsx
+++ b/apps/web/app/lp/loading.tsx
@@ -1,4 +1,8 @@
-import { SkeletonShimmer, PoolStatsPanelSkeleton, LPPositionCardSkeleton } from "@/components/shared/SkeletonLoader";
+import {
+  SkeletonShimmer,
+  PoolStatsPanelSkeleton,
+  LPPositionCardSkeleton,
+} from "@/components/shared/SkeletonLoader";
 
 export default function LPLoading() {
   return (

--- a/apps/web/app/marketplace/loading.tsx
+++ b/apps/web/app/marketplace/loading.tsx
@@ -1,4 +1,7 @@
-import { SkeletonShimmer, InvoiceTableSkeleton } from "@/components/shared/SkeletonLoader";
+import {
+  SkeletonShimmer,
+  InvoiceTableSkeleton,
+} from "@/components/shared/SkeletonLoader";
 
 export default function MarketplaceLoading() {
   return (

--- a/apps/web/components/shared/ErrorBoundary.test.tsx
+++ b/apps/web/components/shared/ErrorBoundary.test.tsx
@@ -53,6 +53,24 @@ describe("ErrorBoundary", () => {
         screen.getByText("Something went wrong loading this."),
       ).toBeInTheDocument();
       expect(screen.getByText("Child failed")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Reload page" }),
+      ).toBeInTheDocument();
+
+      const reload = vi.fn();
+      const originalLocation = window.location;
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: { ...originalLocation, reload },
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Reload page" }));
+      expect(reload).toHaveBeenCalledOnce();
+
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
 
       fireEvent.click(screen.getByRole("button", { name: "Try again" }));
 

--- a/apps/web/components/shared/ErrorBoundary.tsx
+++ b/apps/web/components/shared/ErrorBoundary.tsx
@@ -69,6 +69,12 @@ function DefaultErrorFallback({
       >
         Try again
       </button>
+      <button
+        onClick={() => window.location.reload()}
+        className="rounded-md border border-red-700/60 px-3 py-1.5 text-xs text-red-300/80 transition hover:bg-red-900/20"
+      >
+        Reload page
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a `Reload page` action to the default `ErrorBoundary` fallback
- preserve the existing `Try again` reset behavior
- add regression coverage verifying both actions and the reload behavior

## Validation
- `pnpm --dir apps/web test -- components/shared/ErrorBoundary.test.tsx`
- `npx prettier --check apps/web/components/shared/ErrorBoundary.tsx apps/web/components/shared/ErrorBoundary.test.tsx`
- diagnostics report no errors for the changed files

Closes #653