### PR TITLE
perf(web): memoize RegistryClient in useProfile to stop per-call client churn (#660)

### DIFF
--- a/apps/web/hooks/useProfile.test.ts
+++ b/apps/web/hooks/useProfile.test.ts
@@ -235,6 +235,43 @@ describe("useProfile", () => {
     ).rejects.toThrow("On-chain error");
   });
 
+  it("constructs exactly one RegistryClient instance per mount", async () => {
+    act(() => {
+      useWalletStore.getState().connect("G123", "testnet");
+    });
+
+    vi.mocked(RegistryClient).mockImplementation(function () {
+      return {
+        getProfile: vi.fn().mockResolvedValue(null),
+        isVerified: vi.fn().mockResolvedValue(false),
+        registerIssuer: vi.fn().mockResolvedValue("tx_hash"),
+        registerBuyer: vi.fn().mockResolvedValue("tx_hash"),
+      };
+    } as any);
+
+    const { result, rerender, unmount } = renderHook(() => useProfile());
+
+    // Re-renders, refetches, and mutations must all reuse the memoized client.
+    rerender();
+    await act(async () => {
+      await result.current.register({
+        role: "issuer",
+        metadata: { name: "Test Issuer" },
+      });
+      await result.current.refetchProfile();
+    });
+
+    expect(vi.mocked(RegistryClient)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(RegistryClient)).toHaveBeenCalledWith(
+      process.env.NEXT_PUBLIC_REGISTRY_CONTRACT_ID || "",
+    );
+
+    // A fresh mount constructs a new (single) client instance.
+    unmount();
+    renderHook(() => useProfile());
+    expect(vi.mocked(RegistryClient)).toHaveBeenCalledTimes(2);
+  });
+
   it("refetchProfile refetches both queries", async () => {
     const refetch1 = vi.fn().mockResolvedValue(undefined);
     const refetch2 = vi.fn().mockResolvedValue(undefined);

--- a/apps/web/hooks/useProfile.ts
+++ b/apps/web/hooks/useProfile.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { RegistryClient, Profile } from "@trusttrove/sdk";
 import { useWalletStore } from "@/store/wallet";
@@ -66,13 +67,23 @@ export function useProfile() {
   const address = useWalletStore((s) => s.address);
   const { error: appError, handleError, clearError } = useAppError();
 
+  // Construct a single SDK client per mount and reuse it across all queries
+  // and mutations so refetches/polls don't churn new client objects.
+  const registryClient = useMemo(() => {
+    try {
+      return new RegistryClient(registryContractID);
+    } catch {
+      return null;
+    }
+  }, []);
+
   const profileQuery = useQuery({
     queryKey: ["profile", address],
     queryFn: async (): Promise<Profile | null> => {
       if (!address) return null;
-      const client = new RegistryClient(registryContractID);
+      if (!registryClient) throw new Error("Registry client not available");
       try {
-        const profile = await client.getProfile(address, address);
+        const profile = await registryClient.getProfile(address, address);
         return profile;
       } catch (err) {
         if (isProfileNotFoundError(err)) {
@@ -90,9 +101,9 @@ export function useProfile() {
     queryKey: ["isVerified", address],
     queryFn: async (): Promise<boolean> => {
       if (!address) return false;
-      const client = new RegistryClient(registryContractID);
+      if (!registryClient) throw new Error("Registry client not available");
       try {
-        const verified = await client.isVerified(address, address);
+        const verified = await registryClient.isVerified(address, address);
         return verified;
       } catch (err) {
         captureError(err);
@@ -111,11 +122,11 @@ export function useProfile() {
       metadata: Record<string, string>;
     }) => {
       if (!address) throw new Error("Wallet not connected");
-      const client = new RegistryClient(registryContractID);
+      if (!registryClient) throw new Error("Registry client not available");
       if (role === "issuer") {
-        return client.registerIssuer(address, metadata, address);
+        return registryClient.registerIssuer(address, metadata, address);
       } else {
-        return client.registerBuyer(address, metadata, address);
+        return registryClient.registerBuyer(address, metadata, address);
       }
     },
     onSuccess: () => {


### PR DESCRIPTION
## Summary

Closes #660

Memoizes a single `RegistryClient` instance in `useProfile` so the SDK client is constructed **once per hook mount** and reused across all three call sites (profile fetch, verified-state fetch, and register mutation), instead of being re-constructed on every queryFn/mutationFn invocation.

## Problem

`apps/web/hooks/useProfile.ts` constructed `new RegistryClient(registryContractID)` independently in three separate places:

1. `profileQuery`'s `queryFn` (~line 73)
2. `isVerifiedQuery`'s `queryFn` (~line 93)
3. `registerMutation`'s `mutationFn` (~line 114)

Because those factories run on every query/mutation execution, each refetch — including interval/polling-based refetches — and each register call spun up a brand-new SDK client object (which internally builds a Stellar `Contract` instance and validates the contract ID). This is avoidable object churn on a hook that refetches regularly.

## Root Cause

The client object is stateless for the purpose of these calls — the contract ID is a module-level constant (`registryContractID`), so nothing about the client depends on the wallet address, query args, or render state. There is no reason to rebuild it per call.

## Solution

Following the existing pattern already established in `usePool.ts` (`const poolClient = useMemo(() => new PoolClient(poolContractID), [])`):

- Added a single `registryClient` created inside `useMemo(..., [])` at the top of `useProfile`, so it is constructed exactly once per mount.
- Replaced all three `new RegistryClient(registryContractID)` call sites with the memoized `registryClient`.
- Mirrored `usePool`'s defensive handling: the `useMemo` wraps construction in a `try/catch` and falls back to `null`, and each call site guards with `throw new Error("Registry client not available")`. This keeps the graceful error behavior for misconfigured environments (empty `NEXT_PUBLIC_REGISTRY_CONTRACT_ID`) intact — previously the constructor error surfaced when a query/mutation ran, and it still surfaces at the point of use instead of crashing the render (the hook is used by `Navbar`, so a render-time throw would break every page).

### Files changed

| File | Change |
| --- | --- |
| `apps/web/hooks/useProfile.ts` | Add `useMemo`-memoized `registryClient`; reuse it in all three call sites with null guards |
| `apps/web/hooks/useProfile.test.ts` | New acceptance test asserting the `RegistryClient` constructor is called exactly once per mount |

## Acceptance Criteria Verification

The issue's acceptance criteria:

> useProfile constructs exactly one RegistryClient instance per mount, verified by a test that spies on the RegistryClient constructor.

Covered by the new test `"constructs exactly one RegistryClient instance per mount"`, which:
- Mounts the hook with a connected wallet,
- Triggers a re-render, a register mutation, and a `refetchProfile()` (both queries refetched),
- Asserts `RegistryClient` was constructed exactly **once** and with the expected contract ID,
- Unmounts and remounts to assert a fresh mount constructs a fresh single instance (total of two constructions across two mounts).

## Local Verification (all CI pre-checks pass)

Ran the same checks CI runs in `.github/workflows/ci.yml` on this branch:

- ✅ `pnpm typecheck` — TypeScript passes across SDK + web workspaces (after `@trusttrove/sdk build`, matching CI's build-first order)
- ✅ `pnpm test` — SDK suite + all 425 web tests pass (11/11 in `useProfile.test.ts`)
- ✅ `pnpm --filter web lint` — clean (only pre-existing warnings, no errors)
- ✅ `pnpm build` (with the CI contract-ID env vars) — SDK + Next.js production build succeed
- ✅ `npx prettier --check .` — all files formatted
- ✅ Go backend checks (unchanged by this PR, verified green): `go build ./...`, `go vet ./...`, `go test ./...`

## Testing Notes

All existing component/page tests (`Navbar`, `InvoiceCard`, `marketplace`, `dashboard`, `profile`) mock `@/hooks/useProfile` entirely, so no other tests are affected by this change. The SDK and contract layers are untouched.

## Checklist

- [x] Code follows existing repo conventions (mirrors `usePool.ts`)
- [x] Tests added for the acceptance criteria
- [x] All CI checks (frontend + backend) pass locally
- [x] Prettier formatting enforced
